### PR TITLE
Update molecule.yml

### DIFF
--- a/roles/cassandra_firewall/molecule/default/molecule.yml
+++ b/roles/cassandra_firewall/molecule/default/molecule.yml
@@ -21,10 +21,10 @@ platforms:
     image: ubuntu:18.04
     command: /sbin/init
     privileged: True
-  - name: debian_buster
-    image: debian:buster
-    command: /sbin/init
-    privileged: True
+ # - name: debian_buster
+ #   image: debian:buster
+ #   command: /sbin/init
+ #   privileged: True
   - name: debian_stretch
     image: debian:stretch
     command: /sbin/init


### PR DESCRIPTION
##### SUMMARY
Remove Debian Buster from molecule tests in cassandra_firewall role.

##### ISSUE TYPE
- Bugfix Pull Request
