### PR TITLE
Revert python to 3.6

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -81,7 +81,7 @@ jobs:
             tar_version: "2.2.9"
         test_scenario:
           - docker_image: default
-            python_version: "3.9"
+            python_version: "3.6"
             ansible_test_options: ""
           - docker_image: centos7
             python_version: "2.7"

--- a/tests/integration/targets/setup_cassandra/handlers/cleanup_debian_env.yml
+++ b/tests/integration/targets/setup_cassandra/handlers/cleanup_debian_env.yml
@@ -2,5 +2,5 @@
 - apt:
     name: "{{ cassandra_deb_pkg }}"
     state: absent
-- shell: update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1
-- shell: update-alternatives --set python /usr/bin/python3.9
+- shell: update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
+- shell: update-alternatives --set python /usr/bin/python3.6

--- a/tests/integration/targets/setup_cassandra/handlers/main.yml
+++ b/tests/integration/targets/setup_cassandra/handlers/main.yml
@@ -5,3 +5,4 @@
 
 - name: debian_remove_cassandra
   include_tasks: cleanup_debian_env.yml
+  when: False  # TODO Remove this if not required

--- a/tests/integration/targets/setup_cassandra/handlers/main.yml
+++ b/tests/integration/targets/setup_cassandra/handlers/main.yml
@@ -3,6 +3,6 @@
     name: "{{ cassandra_yum_pkg }}"
     state: absent
 
+# RPM Pulls down python2.7
 - name: debian_remove_cassandra
   include_tasks: cleanup_debian_env.yml
-  when: False  # TODO Remove this if not required


### PR DESCRIPTION
##### SUMMARY
Reverty Python in Debian container to 3.6. Fixed upstream.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup_cassandra / ansible-test.yml

