### PR TITLE
Add setuptool upgrade task

### DIFF
--- a/tests/integration/targets/setup_cassandra/handlers/cleanup_redhat7_env.yml
+++ b/tests/integration/targets/setup_cassandra/handlers/cleanup_redhat7_env.yml
@@ -2,3 +2,7 @@
   yum:
     name: "{{ cassandra_yum_pkg }}"
     state: absent
+
+- name: Downgrade pip
+  pip:
+    name: pip==8.1.2

--- a/tests/integration/targets/setup_cassandra/handlers/cleanup_redhat7_env.yml
+++ b/tests/integration/targets/setup_cassandra/handlers/cleanup_redhat7_env.yml
@@ -3,6 +3,9 @@
     name: "{{ cassandra_yum_pkg }}"
     state: absent
 
-- name: Downgrade pip
+- name: Downgrade pip when CentOS 7
   pip:
     name: pip==8.1.2
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == "7"

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -240,11 +240,10 @@
   register: current_python
   when: ansible_os_family == "Debian"
 
-- name: Upgrade pip libs
+- name: Upgrade pip libs to 20.3.4 for py2.7
   pip:
-    name: "{{ item }}"
+    name: pip==20.3.4
     extra_args: "--upgrade"
-  with_items:
-    - pip
-    - typing==3.7.4.3
-    - setuptools==56.1.0
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == "7"

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -246,5 +246,4 @@
     extra_args: "--upgrade"
   with_items:
     - pip
-    - typing==3.7.4.3
-    - setuptools
+    - setuptools==56.1.0

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -246,5 +246,5 @@
     extra_args: "--upgrade"
   with_items:
     - pip
-    - typing
+    - typing==3.7.4.3
     - setuptools

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -247,3 +247,4 @@
   when:
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version == "7"
+  notify: redhat_remove_cassandra

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -246,4 +246,5 @@
     extra_args: "--upgrade"
   with_items:
     - pip
+    - typing
     - setuptools

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -240,7 +240,10 @@
   register: current_python
   when: ansible_os_family == "Debian"
 
-- name: Upgrade setuptools
+- name: Upgrade pip libs
   pip:
-    name: setuptools
+    name: "{{ item }}"
     extra_args: "--upgrade"
+  with_items:
+    - pip
+    - setuptools

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -239,3 +239,8 @@
   shell: python --version && pip --version
   register: current_python
   when: ansible_os_family == "Debian"
+
+- name: Upgrade setuptools
+  pip:
+    name: setuptools
+    extra_args: "--upgrade"

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -246,4 +246,5 @@
     extra_args: "--upgrade"
   with_items:
     - pip
+    - typing==3.7.4.3
     - setuptools==56.1.0


### PR DESCRIPTION
##### SUMMARY
Add setuptool upgrade task. Attempt to fix CI issue...

> TASK [cassandra_cqlsh : Install cassandra-driver] ******************************
> fatal: [testhost]: FAILED! => {"changed": false, "cmd": ["/usr/bin/pip2", "install", "cassandra-driver"], "msg": "stdout: Collecting cassandra-driver\n  Downloading https://files.pythonhosted.org/packages/af/aa/3d3a6dae349d4f9b69d37e6f3f8b8ef286a06005aa312f0a3dc7af0eb556/cassandra-driver-3.25.0.tar.gz (289kB)\nRequirement already satisfied (use --upgrade to upgrade): six>=1.9 in /usr/lib/python2.7/site-packages (from cassandra-driver)\nCollecting geomet<0.3,>=0.1 (from cassandra-driver)\n  Downloading https://files.pythonhosted.org/packages/cf/21/58251b3de99e0b5ba649ff511f7f9e8399c3059dd52a643774106e929afa/geomet-0.2.1.post1.tar.gz\nCollecting futures (from cassandra-driver)\n  Downloading https://files.pythonhosted.org/packages/d8/a6/f46ae3f1da0cd4361c344888f59ec2f5785e69c872e175a748ef6071cdb5/futures-3.3.0-py2-none-any.whl\nCollecting click (from geomet<0.3,>=0.1->cassandra-driver)\n  Downloading https://files.pythonhosted.org/packages/d5/99/286fd2fdfb501620a9341319ba47444040c7b3094d3b6c797d7281469bf8/click-8.0.0.tar.gz (326kB)\n    Complete output from command python setup.py egg_info:\n    error in click setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers\n    \n    ----------------------------------------\n\n:stderr: Command \"python setup.py egg_info\" failed with error code 1 in /tmp/pip-build-GfqgMA/click/\nYou are using pip version 8.1.2, however version 21.1.1 is available.\nYou should consider upgrading via the 'pip install --upgrade pip' command.\n"}

As seen in https://github.com/ansible-collections/community.cassandra/runs/2572291762?check_suite_focus=true

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup_cassandra
