### PR TITLE
cassandra_cqlsh: Fix import error

### DIFF
--- a/roles/cassandra_install/tasks/main.yml
+++ b/roles/cassandra_install/tasks/main.yml
@@ -19,4 +19,3 @@
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version == "7"
     - "cassandra_version.startswith('4') or cassandra_version.startswith('3')"
-  notify: redhat_remove_cassandra

--- a/roles/cassandra_install/tasks/main.yml
+++ b/roles/cassandra_install/tasks/main.yml
@@ -15,6 +15,8 @@
 # https://issues.apache.org/jira/browse/CASSANDRA-16822?orderby=created+DESC%2C+priority+DESC%2C+updated+DESC
 - name: Install clqshlib - bug - ImportError - No module named cqlshlib
   shell: cp -r /usr/lib/python3.6/site-packages/cqlshlib /usr/lib/python2.7/site-packages/cqlshlib
+  args:
+    creates: /usr/lib/python2.7/site-packages/cqlshlib
   when:
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version == "7"

--- a/roles/cassandra_install/tasks/main.yml
+++ b/roles/cassandra_install/tasks/main.yml
@@ -11,3 +11,12 @@
   package:
     name: "{{ cassandra_packages }}"
     state: present
+
+# https://issues.apache.org/jira/browse/CASSANDRA-16822?orderby=created+DESC%2C+priority+DESC%2C+updated+DESC
+- name: Install clqshlib - bug - ImportError - No module named cqlshlib
+  shell: cp -r /usr/lib/python3.6/site-packages/cqlshlib /usr/lib/python2.7/site-packages/cqlshlib
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == "7"
+    - "cassandra_version.startswith('4') or cassandra_version.startswith('3')"
+  notify: redhat_remove_cassandra

--- a/tests/integration/targets/cassandra_cqlsh/tasks/main.yml
+++ b/tests/integration/targets/cassandra_cqlsh/tasks/main.yml
@@ -26,6 +26,7 @@
 - name: Run the DESC KEYSPACES command
   community.cassandra.cassandra_cqlsh:
     execute: "DESC KEYSPACES"
+    debug: yes
   register: cqlsh
 
 - assert:

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -258,5 +258,5 @@
   when:
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version == "7"
-    - "cassandra_version.startswith('4')"
+    - "cassandra_version.startswith('4') or cassandra_version.startswith('3')"
   notify: redhat_remove_cassandra

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -258,4 +258,5 @@
   when:
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version == "7"
+    - "cassandra_version.startswith('4')"
   notify: redhat_remove_cassandra

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -254,10 +254,7 @@
   notify: redhat_remove_cassandra
 
 - name: Install clqshlib - bug - ImportError - No module named cqlshlib
-  pip:
-    name:
-      - "cassandra-driver==3.24.0"
-      - "cqlsh"
+  shell: cp -r /usr/lib/python3.6/site-packages/cqlshlib /usr/lib/python2.7/site-packages/cqlshlib
   when:
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version == "7"

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -252,3 +252,13 @@
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version == "7"
   notify: redhat_remove_cassandra
+
+- name: Install clqshlib - bug - ImportError - No module named cqlshlib
+  pip:
+    name:
+      - "cassandra-driver==3.24.0"
+      - "cqlsh"
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == "7"
+  notify: redhat_remove_cassandra


### PR DESCRIPTION
##### SUMMARY

Fixes import error seen when running cqlsh with 311x.

```
Traceback (most recent call last):
  File "/usr/bin/cqlsh.py", line 169, in <module>
    from cqlshlib import cql3handling, cqlhandling, pylexotron, sslhandling, cqlshhandling
ImportError: No module named cqlshlib

```
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cassandra_cqlsh
