### PR TITLE
match brackets better

### DIFF
--- a/plugins/modules/cassandra_keyspace.py
+++ b/plugins/modules/cassandra_keyspace.py
@@ -186,7 +186,7 @@ def drop_keyspace(session, keyspace):
 
 def get_keyspace_config(module, cluster, keyspace):
     cql = get_keyspace(cluster, keyspace)
-    dict_regexp = re.compile(r'{([\S\s]*)}')
+    dict_regexp = re.compile(r'{(.*)}')
     durable_writes_regexp = re.compile('DURABLE_WRITES = (True|False);')
     repl_settings = re.search(dict_regexp, cql).group(0)
     try:

--- a/tests/integration/targets/cassandra_keyspace/tasks/main.yml
+++ b/tests/integration/targets/cassandra_keyspace/tasks/main.yml
@@ -347,6 +347,22 @@
       - "'rhys2' not in mykeyspace.stdout"
       - "drop_rhys2.changed == True"
 
+- name: Test cassandra_keyspace module regex
+  block:
+    - name: Create a testregex keyspace
+      community.cassandra.cassandra_keyspace:
+        name: testregex_keyspace
+        state: present
+
+    - name: Create table with brackets for regex testing
+      # Colons had to be escaped to avoid mapping yaml values
+      shell: cqlsh --execute "CREATE TABLE testregex_keyspace.tablewithbrackets (groupid uuid, containinggroupid uuid, PRIMARY KEY (groupid, containinggroupid)) WITH CLUSTERING ORDER BY (containinggroupid ASC) AND caching = {'keys'{{ ":" }} 'ALL', 'rows_per_partition'{{ ":" }} 'NONE'}"
+
+    - name: Rerun cassandra_keyspace command
+      community.cassandra.cassandra_keyspace:
+        name: testregex_keyspace
+        state: present
+
 - name: Multi DC Tests - Temp Skip on Cassandra 4.0
   block:
     - name: Create keyspace with several data centres


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixing matching pattern to better match content between brackets.  Previous pattern would match brackets across different lines and cause the following error:
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "An error occured: invalid syntax (<string>, line 1)"}
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module:  cassandra_keyspace

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

SAMPLE KEYSPACE
```paste below
CREATE KEYSPACE test_keyspace WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3'}  AND durable_writes = true;

CREATE TABLE test_keyspace.database_migrations (
    id uuid PRIMARY KEY,
    applied_at timestamp,
    checksum blob,
    content text,
    name text,
    state text,
    version int
) WITH bloom_filter_fp_chance = 0.01
    AND caching = {'keys': 'NONE', 'rows_per_partition': 'NONE'}
    AND comment = ''
    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
    AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
    AND crc_check_chance = 1.0
    AND dclocal_read_repair_chance = 0.1
    AND default_time_to_live = 0
    AND gc_grace_seconds = 864000
    AND max_index_interval = 2048
    AND memtable_flush_period_in_ms = 0
    AND min_index_interval = 128
    AND read_repair_chance = 0.0
    AND speculative_retry = '99PERCENTILE';
```

PREVIOUS MATCH PATTERN `{([\S\s]*)}` RESULTS
```
{'class': 'NetworkTopologyStrategy', 'DC1': '3'} AND durable_writes = true;

CREATE TABLE test_keyspace.database_migrations (
id uuid PRIMARY KEY,
applied_at timestamp,
checksum blob,
content text,
name text,
state text,
version int
) WITH bloom_filter_fp_chance = 0.01
AND caching = {'keys': 'NONE', 'rows_per_partition': 'NONE'}
AND comment = ''
AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
AND compression = {'chunk_length_in_kb': '64', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
```

NEW MATCH PATTERN `{(.*)}` RESULTS
```
'class': 'NetworkTopologyStrategy', 'DC1': '3'
```