### PR TITLE
Update cassandra_cqlsh.py

### DIFF
--- a/plugins/modules/cassandra_cqlsh.py
+++ b/plugins/modules/cassandra_cqlsh.py
@@ -306,6 +306,7 @@ def main():
     args = add_arg_to_cmd(args, "--tty", None, module.params['tty'])
     args = add_arg_to_cmd(args, "--debug", None, module.params['debug'])
     args = add_arg_to_cmd(args, "--no-compact", None, module.params['no_compact'])
+    args = add_arg_to_cmd(args, "--ssl", None, module.params['ssl'])
 
     additional_args = module.params['additional_args']
     if additional_args is not None:


### PR DESCRIPTION
Missing handler for `--ssl` option for `cassandra_cqlsh`

##### SUMMARY
SSL argument is parsed by module, but actually never used.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`community.cassandra.cassandra_cqlsh`
