### PR TITLE
Quoting for role names

### DIFF
--- a/plugins/modules/cassandra_role.py
+++ b/plugins/modules/cassandra_role.py
@@ -215,9 +215,9 @@ def is_role_changed(role_properties, super_user, login, password,
 def create_alter_role(module, session, role, super_user, login, password,
                       options, data_centers, alter_role):
     if alter_role is False:
-        cql = "CREATE ROLE {0} ".format(role)
+        cql = "CREATE ROLE '{0}' ".format(role)
     else:
-        cql = "ALTER ROLE {0} ".format(role)
+        cql = "ALTER ROLE '{0}' ".format(role)
     cql += "WITH SUPERUSER = {0} ".format(super_user)
     cql += "AND LOGIN = {0} ".format(login)
     if password is not None:
@@ -242,14 +242,14 @@ def create_alter_role(module, session, role, super_user, login, password,
 def create_role(session, role):
     ''' Used for creating roles that are assigned to other users
     '''
-    cql = "CREATE ROLE {0}".format(role)
+    cql = "CREATE ROLE '{0}'".format(role)
     return cql
 
 
 def grant_role(session, role, grantee):
     ''' Assign roles to other roles
     '''
-    cql = "GRANT {0} TO {1}".format(role,
+    cql = "GRANT '{0}' TO '{1}'".format(role,
                                     grantee)
     return cql
 
@@ -257,13 +257,13 @@ def grant_role(session, role, grantee):
 def revoke_role(session, role, grantee):
     ''' Revoke a role
     '''
-    cql = "REVOKE {0} FROM {1}".format(role,
+    cql = "REVOKE '{0}' FROM '{1}'".format(role,
                                        grantee)
     return cql
 
 
 def drop_role(session, role):
-    cql = "DROP ROLE {0}".format(role)
+    cql = "DROP ROLE '{0}'".format(role)
     return cql
 
 
@@ -292,17 +292,17 @@ def validate_keyspace_permissions(keyspace_permissions):
 
 def grant_permission(session, permission, role, keyspace):
     if keyspace == "all_keyspaces":
-        cql = "GRANT {0} ON ALL KEYSPACES TO {1}".format(permission,
+        cql = "GRANT {0} ON ALL KEYSPACES TO '{1}'".format(permission,
                                                          role)
     else:
-        cql = "GRANT {0} ON KEYSPACE {1} TO {2}".format(permission,
+        cql = "GRANT {0} ON KEYSPACE {1} TO '{2}'".format(permission,
                                                         keyspace,
                                                         role)
     return cql
 
 
 def revoke_permission(session, permission, role, keyspace):
-    cql = "REVOKE {0} ON KEYSPACE {1} FROM {2}".format(permission,
+    cql = "REVOKE {0} ON KEYSPACE {1} FROM '{2}'".format(permission,
                                                        keyspace,
                                                        role)
     return cql
@@ -328,7 +328,7 @@ def list_role_permissions(session, role):
 
      Returns a resultset object of dicts
     '''
-    cql = "LIST ALL OF {0}".format(role)
+    cql = "LIST ALL OF '{0}'".format(role)
     session.row_factory = dict_factory
     try:
         role_permissions = session.execute(cql)
@@ -473,7 +473,7 @@ def build_role_permissions(session,
                 if permission['resource'] == "<all keyspaces>"\
                         and "all_keyspaces" not in keyspace_permissions.keys()\
                         and permission['role'] == role:
-                    cql = "REVOKE ALL PERMISSIONS ON ALL KEYSPACES FROM {0}".format(role)
+                    cql = "REVOKE ALL PERMISSIONS ON ALL KEYSPACES FROM '{0}'".format(role)
                     if cql not in perms_dict['revoke']:  # only do this the once
                         perms_dict['revoke'].add(cql)
                 elif permission['resource'] == "<all keyspaces>" \

--- a/plugins/modules/cassandra_role.py
+++ b/plugins/modules/cassandra_role.py
@@ -250,7 +250,7 @@ def grant_role(session, role, grantee):
     ''' Assign roles to other roles
     '''
     cql = "GRANT '{0}' TO '{1}'".format(role,
-                                    grantee)
+                                        grantee)
     return cql
 
 
@@ -258,7 +258,7 @@ def revoke_role(session, role, grantee):
     ''' Revoke a role
     '''
     cql = "REVOKE '{0}' FROM '{1}'".format(role,
-                                       grantee)
+                                           grantee)
     return cql
 
 
@@ -293,18 +293,18 @@ def validate_keyspace_permissions(keyspace_permissions):
 def grant_permission(session, permission, role, keyspace):
     if keyspace == "all_keyspaces":
         cql = "GRANT {0} ON ALL KEYSPACES TO '{1}'".format(permission,
-                                                         role)
+                                                           role)
     else:
         cql = "GRANT {0} ON KEYSPACE {1} TO '{2}'".format(permission,
-                                                        keyspace,
-                                                        role)
+                                                          keyspace,
+                                                          role)
     return cql
 
 
 def revoke_permission(session, permission, role, keyspace):
     cql = "REVOKE {0} ON KEYSPACE {1} FROM '{2}'".format(permission,
-                                                       keyspace,
-                                                       role)
+                                                         keyspace,
+                                                         role)
     return cql
 
 

--- a/tests/integration/targets/cassandra_role/tasks/204.yml
+++ b/tests/integration/targets/cassandra_role/tasks/204.yml
@@ -42,8 +42,8 @@
 - assert:
     that:
       - first_run.changed
-      - first_run.cql == "CREATE ROLE test_role WITH SUPERUSER = False AND LOGIN = True AND PASSWORD = '********' "
-      - "first_run.permissions.grant.0 == 'GRANT ALL PERMISSIONS ON KEYSPACE test_keyspace TO test_role'"
+      - first_run.cql == "CREATE ROLE 'test_role' WITH SUPERUSER = False AND LOGIN = True AND PASSWORD = '********' "
+      - "first_run.permissions.grant.0 == \"GRANT ALL PERMISSIONS ON KEYSPACE test_keyspace TO 'test_role'\""
       - "{{ first_run.permissions.grant | length }} == 1"
       - "{{ first_run.permissions.revoke | length }} == 0"
 
@@ -148,7 +148,7 @@
       - sixth_run.changed
       - "{{ sixth_run.permissions.revoke | length }} == 0"
       - "{{ sixth_run.permissions.grant | length }} == 1"
-      - "sixth_run.permissions.grant.0 == 'GRANT MODIFY ON KEYSPACE test_keyspace TO test_role'"
+      - "sixth_run.permissions.grant.0 == \"GRANT MODIFY ON KEYSPACE test_keyspace TO 'test_role'\""
 
 - name: Create a test role - seventh run
   community.cassandra.cassandra_role:
@@ -170,7 +170,7 @@
       - seventh_run.changed
       - "{{ seventh_run.permissions.revoke | length }} == 0"
       - "{{ seventh_run.permissions.grant | length }} == 1"
-      - "seventh_run.permissions.grant.0 == 'GRANT MODIFY ON KEYSPACE test_keyspace TO test_role'"
+      - "seventh_run.permissions.grant.0 == \"GRANT MODIFY ON KEYSPACE test_keyspace TO 'test_role'\""
 
 - name: Create a test role - eighth run
   community.cassandra.cassandra_role:

--- a/tests/integration/targets/cassandra_role/tasks/main.yml
+++ b/tests/integration/targets/cassandra_role/tasks/main.yml
@@ -270,7 +270,7 @@
 - assert:
     that:
       - "app_user_multi_keyspace.changed == True"
-      - "app_user_multi_keyspace.cql == \"CREATE ROLE app_user_multi_keyspace WITH SUPERUSER = False AND LOGIN = True AND PASSWORD = '********' \""
+      - "app_user_multi_keyspace.cql == \"CREATE ROLE 'app_user_multi_keyspace' WITH SUPERUSER = False AND LOGIN = True AND PASSWORD = '********' \""
       - "app_user_multi_keyspace.role == 'app_user_multi_keyspace'"
 
 - name: Get output of list roles
@@ -424,7 +424,7 @@
 - assert:
     that:
       - "myapp.changed == True"
-      - "'CREATE ROLE myapp WITH SUPERUSER = False AND LOGIN = True AND PASSWORD' in myapp.cql"
+      - "\"CREATE ROLE 'myapp' WITH SUPERUSER = False AND LOGIN = True AND PASSWORD\" in myapp.cql"
       # TODO Check permissions grant and revoke statement
 
 - name: Get output of list permissions for rw_role
@@ -492,7 +492,7 @@
 - assert:
     that:
       - "myapp.changed == True"
-      - "myapp.permissions['grant'] == [\"GRANT SELECT ON KEYSPACE mykeyspace1 TO myapp\"]"
+      - "myapp.permissions['grant'] == [\"GRANT SELECT ON KEYSPACE mykeyspace1 TO 'myapp'\"]"
       - "'roles' not in myapp.keys()"
 
 - name: Get output of list permissions for rw_role
@@ -526,7 +526,7 @@
 - assert:
     that:
       - "myapp.changed == True"
-      - "myapp.permissions['revoke'] == [\"REVOKE ALTER ON KEYSPACE mykeyspace1 FROM myapp\"]"
+      - "myapp.permissions['revoke'] == [\"REVOKE ALTER ON KEYSPACE mykeyspace1 FROM 'myapp'\"]"
       - "'roles' not in myapp.keys()"
 
 - name: Get output of list permissions for rw_role
@@ -658,6 +658,104 @@
       - "'<keyspace mykeyspace6> |     SELECT' in complex.stdout"
       - "'rw_role |        <all keyspaces> |     SELECT' in complex.stdout"
       - "'rw_role |        <all keyspaces> |     MODIFY' in complex.stdout"
+
+- name: Create a role with dash in name
+  community.cassandra.cassandra_role:
+    name: app-user
+    password: 'secretZHB78'
+    state: present
+    login: yes
+    login_user: "{{ cassandra_admin_user }}"
+    login_password: "{{ cassandra_admin_pwd }}"
+  register: create_role
+
+- assert:
+    that:
+      - 'create_role.changed == True'
+
+- name: Get output of list roles
+  ansible.builtin.shell: cqlsh --username "{{ cassandra_admin_user }}" --password "{{ cassandra_admin_pwd }}" --execute "LIST ROLES"
+  register: myrole
+
+- name: Assert app-user exists in output
+  assert:
+    that:
+      - "'app-user' in myrole.stdout"
+
+- name: Remove a role with dash in name
+  community.cassandra.cassandra_role:
+    name: app-user
+    state: absent
+    login_user: "{{ cassandra_admin_user }}"
+    login_password: "{{ cassandra_admin_pwd }}"
+  register: absent
+
+- name: Assert role changed
+  assert:
+    that:
+      - "absent.changed == True"
+
+- name: Get output of list roles
+  ansible.builtin.shell: cqlsh --username "{{ cassandra_admin_user }}" --password "{{ cassandra_admin_pwd }}" --execute "LIST ROLES"
+  register: myrole
+
+- name: Assert app-user does not exist
+  assert:
+    that:
+      - "'app-user' not in myrole.stdout"
+
+- name: Create a user with permissions and dash in name
+  community.cassandra.cassandra_role:
+    name: user-with-perms
+    password: "secret"
+    state: present
+    keyspace_permissions:
+      all_keyspaces:
+        - SELECT
+    login: yes
+    login_user: "{{ cassandra_admin_user }}"
+    login_password: "{{ cassandra_admin_pwd }}"
+  register: user_with_perms
+
+- assert:
+    that: "user_with_perms.changed == True"
+
+- name: Get output of list permissions for user-with-perms user
+  ansible.builtin.shell: cqlsh --username "{{ cassandra_admin_user }}" --password "{{ cassandra_admin_pwd }}" --execute "LIST ALL PERMISSIONS OF 'user-with-perms'"
+  register: user_with_perms_perms
+
+- name: Assert that all keyspaces select permissions exists
+  assert:
+    that:
+      - "'<all keyspaces> |     SELECT' in user_with_perms_perms.stdout"
+      - "'(1 rows)' in user_with_perms_perms.stdout"
+
+- name: Run user-with-perms but remove all_keyspaces permission and add another
+  community.cassandra.cassandra_role:
+    name: user-with-perms
+    password: "secret"
+    state: present
+    keyspace_permissions:
+      mykeyspace1:
+        - SELECT
+    login: yes
+    login_user: "{{ cassandra_admin_user }}"
+    login_password: "{{ cassandra_admin_pwd }}"
+  register: user_with_perms
+
+- assert:
+    that: "user_with_perms.changed == True"
+
+- name: Get output of list permissions for user-with-perms user
+  ansible.builtin.shell: cqlsh --username "{{ cassandra_admin_user }}" --password "{{ cassandra_admin_pwd }}" --execute "LIST ALL PERMISSIONS OF 'user-with-perms'"
+  register: user_with_perms_perms
+
+- name: Assert that all keyspaces select permissions does not exist
+  assert:
+    that:
+      - "'<all keyspaces> |     SELECT' not in user_with_perms_perms.stdout"
+      - "'<keyspace mykeyspace1> |     SELECT' in user_with_perms_perms.stdout"
+      - "'(1 rows)' in user_with_perms_perms.stdout"
 
 - name: Import tasks for issue 204
   import_tasks: 204.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Quoting role names in multiple places to allow for special characters in role names. It was possible to work around this by putting quotes on the input, but the check that checked for existing role had quotes in the code, and failed if you also added your own quotes. The solution should be to quote everything, which should work for normal role names as well (tested on Cassandra 4.0.5).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`cassandra_role`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
