### PR TITLE
Use yum module not dnf

### DIFF
--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -95,10 +95,10 @@
   retries: 3
 
 - name: Install cassandra yum package
-  dnf:
+  yum:
     name: "{{ cassandra_yum_pkg }}"
     state: present
-    allowerasing: yes
+    #allowerasing: yes
   when:
     - ansible_os_family == 'RedHat'
   notify:


### PR DESCRIPTION
##### SUMMARY
Using dnf module breaks the setup for old RedHat images.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup_cassandra