### PR TITLE
Fix unsafe conditional statement

### DIFF
--- a/tests/integration/targets/cassandra_timeout/tasks/timeout_test.yml
+++ b/tests/integration/targets/cassandra_timeout/tasks/timeout_test.yml
@@ -1,4 +1,4 @@
----   
+---
 - name: "Set {{ item }} timeout with module"
   community.cassandra.cassandra_timeout:
     username: "{{ cassandra_admin_user }}"
@@ -9,9 +9,9 @@
   register: result
 
 - assert:
-    that: 
+    that:
       - result.changed
-      - "result.msg == '{{ item }} timeout changed'"
+      - result.msg == "{{ item }} timeout changed"
 
 - name: "Get {{ item }} timeout"
   ansible.builtin.shell: nodetool -u {{ cassandra_admin_user }} -pw {{ cassandra_admin_pwd }} -h 127.0.0.1 gettimeout {{ item }}
@@ -31,7 +31,7 @@
   register: result
 
 - assert:
-    that: 
+    that:
       - "result.changed == False"
       - "result.msg == '{{ item }} timeout unchanged'"
 


### PR DESCRIPTION
##### SUMMARY
Fixes the following error from integration tests...

> TASK [cassandra_timeout : assert] **********************************************
> [WARNING]: conditional statements should not include jinja2 templating
> delimiters such as {{ }} or {% %}. Found: result.msg == '{{ item }} timeout
> changed'
> fatal: [testhost]: FAILED! => {"msg": "The conditional check 'result.msg == '{{ item }} timeout changed'' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated."}

##### ISSUE TYPE
- Bugfix Pull Request