### PR TITLE
Allow for update of role passwords

### DIFF
--- a/tests/integration/targets/cassandra_role/tasks/main.yml
+++ b/tests/integration/targets/cassandra_role/tasks/main.yml
@@ -180,6 +180,10 @@
     login_password: "{{ cassandra_admin_pwd }}"
   register: myrole
 
+- assert:
+    that:
+      - 'myrole.changed == False'
+
 - name: Ensure password not changed
   ansible.builtin.shell: cqlsh --username "app_user" --password "secretZHB78" --execute "CONSISTENCY ONE;"
   register: myrole
@@ -194,6 +198,10 @@
     login_user: "{{ cassandra_admin_user }}"
     login_password: "{{ cassandra_admin_pwd }}"
   register: myrole
+
+- assert:
+    that:
+      - 'myrole.changed == True'
 
 - name: Login with new credentials
   ansible.builtin.shell: cqlsh --username "app_user" --password "secretZHDiff" --execute "CONSISTENCY ONE;"

--- a/tests/integration/targets/cassandra_role/tasks/main.yml
+++ b/tests/integration/targets/cassandra_role/tasks/main.yml
@@ -170,6 +170,35 @@
   register: myrole
   ignore_errors: yes
 
+- name: Change the password of the role without update_password
+  community.cassandra.cassandra_role:
+    name: app_user
+    password: 'secretZHDiff'
+    state: present
+    login: yes
+    login_user: "{{ cassandra_admin_user }}"
+    login_password: "{{ cassandra_admin_pwd }}"
+  register: myrole
+
+- name: Ensure password not changed
+  ansible.builtin.shell: cqlsh --username "app_user" --password "secretZHB78" --execute "CONSISTENCY ONE;"
+  register: myrole
+
+- name: Change the password of the role
+  community.cassandra.cassandra_role:
+    name: app_user
+    password: 'secretZHDiff'
+    update_password: True
+    state: present
+    login: yes
+    login_user: "{{ cassandra_admin_user }}"
+    login_password: "{{ cassandra_admin_pwd }}"
+  register: myrole
+
+- name: Login with new credentials
+  ansible.builtin.shell: cqlsh --username "app_user" --password "secretZHDiff" --execute "CONSISTENCY ONE;"
+  register: myrole
+
 - name: Remove a role (check mode)
   community.cassandra.cassandra_role:
     name: app_user

--- a/tests/integration/targets/setup_cassandra/tasks/cassandra_auth.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/cassandra_auth.yml
@@ -32,6 +32,14 @@
     line: "{{ cassandra_authorizer}}"
   no_log: yes
 
+# Should be replaced by 'nodetool invalidatecredentialscache' in 4.1+
+- name: Disable credential cache
+  lineinfile:
+    path: "{{ cassandra_yml_file }}"
+    regexp: "^credentials_validity"
+    line: 'credentials_validity_in_ms: 0'
+
+
 - name: Add lines for nodetool auth to cassandra-env.sh
   blockinfile:
     marker: "# {mark} ANSIBLE MANAGED BLOCK - nodetool auth"


### PR DESCRIPTION
##### SUMMARY
Quick patch to update passwords I threw together to solve #265 

I also figured out during the work on this that on master, you can update the password by changing super_user status or login_status. Something we should consider adding to the documentation.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cassandra.role
