### PR TITLE
Feature/279 add snapshot modules

### DIFF
--- a/plugins/modules/cassandra_clearsnapshot.py
+++ b/plugins/modules/cassandra_clearsnapshot.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+
+# 2024 Jaymit Patel <18jaymit@gmail.com>
+# https://github.com/jaymitp
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+
+DOCUMENTATION = '''
+---
+module: cassandra_clearsnapshot
+author: Jaymit Patel (@jaymitp)
+short_description: Removes one or more snapshots.
+requirements:
+  - nodetool
+description:
+    - Removes one or more snapshots. 
+    - To remove all snapshots, omit the snapshot name.
+
+extends_documentation_fragment:
+  - community.cassandra.nodetool_module_options
+
+options:
+  keyspace:
+    description:
+      - Optional keyspace to remove snapshots from
+    type: list
+    elements: str
+  name:
+    description:
+      - Optional name of the snapshot to remove
+    type: str
+    aliases:
+      - tag
+      - t
+  debug:
+    description:
+      - Add additional debug to module output. 
+    type: bool
+    default: False 
+   
+'''
+
+EXAMPLES = '''
+- name: Remove all snapshots on the node
+  community.cassandra.cassandra_clearsnapshot:
+
+- name: Remove snapshots from multiple keyspaces on the node
+  community.cassandra.cassandra_snapshot:
+    keyspace: keyspace1, keyspace2
+
+- name: Remove all snapshots named 01-01-2024 from multiple keyspaces
+  community.cassandra.cassandra_snapshot:
+    keyspace: mykeyspace, mykeyspace_1
+    name: 01-01-2024
+'''
+
+RETURN = '''
+msg:
+  description: A message indicating what has happened.
+  returned: on success
+  type: str
+rc:
+  description: Return code of the last executed command.
+  returned: always
+  type: int
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+__metaclass__ = type
+
+
+from ansible_collections.community.cassandra.plugins.module_utils.nodetool_cmd_objects import NodeToolCmd
+from ansible_collections.community.cassandra.plugins.module_utils.cassandra_common_options import cassandra_common_argument_spec
+
+
+class NodeToolClearSnapshotCommand(NodeToolCmd):
+
+    """ 
+    Inherits from the NodeToolCmd class. Adds the following methods;     
+        - run_command 
+    """ 
+    def __init__(self, module, cmd): 
+        NodeToolCmd.__init__(self, module) 
+        self.keyspace = module.params["keyspace"]
+        self.name = module.params["name"]
+      
+        if self.name is not None:
+            cmd = "{0} -t {1}".format(cmd, self.name)
+        if self.keyspace is not None:
+            cmd = "{0} {1}".format(cmd, " ".join(self.keyspace))
+        if self.name is None and self.keyspace is None:
+            cmd = "{0} --all".format(cmd)
+        self.cmd = cmd
+ 
+    def run_command(self): 
+       return self.nodetool_cmd(self.cmd) 
+
+
+def main():
+    argument_spec = cassandra_common_argument_spec()
+    argument_spec.update(
+        keyspace=dict(type='list', elements='str', default=None, required=False),
+        name=dict(type='str', default=None, aliases=['tag','t'], required=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=False,
+    )
+    
+    cmd = "clearsnapshot"
+
+    n = NodeToolSnapshotCommand(module, cmd)
+
+    rc = None
+    out = ''
+    err = ''
+    result = {}
+  
+    (rc, out, err) = n.run_command()
+    out = out.strip()
+    err = err.strip()
+    if module.params['debug']:
+        if out:
+            result['stdout'] = out
+        if err:
+            result['stderr'] = err
+
+    if rc == 0:
+        result['changed'] = True
+        result['msg'] = "nodetool clearsnapshot executed successfully"
+        module.exit_json(**result)
+    else:
+        result['rc'] = rc
+        result['changed'] = False
+        result['msg'] = "nodetool clearsnapshot did not execute successfully"
+        module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/cassandra_clearsnapshot.py
+++ b/plugins/modules/cassandra_clearsnapshot.py
@@ -15,7 +15,7 @@ short_description: Removes one or more snapshots.
 requirements:
   - nodetool
 description:
-    - Removes one or more snapshots. 
+    - Removes one or more snapshots.
     - To remove all snapshots, omit the snapshot name.
 
 extends_documentation_fragment:
@@ -36,9 +36,9 @@ options:
       - t
   debug:
     description:
-      - Add additional debug to module output. 
+      - Add additional debug to module output.
     type: bool
-    default: False 
+    default: False
 '''
 
 EXAMPLES = '''
@@ -47,13 +47,13 @@ EXAMPLES = '''
 
 - name: Remove snapshots from multiple keyspaces on the node
   community.cassandra.cassandra_clearsnapshot:
-    keyspace: 
+    keyspace:
       - keyspace1
       - keyspace2
 
 - name: Remove all snapshots named 01-01-2024 from multiple keyspaces
   community.cassandra.cassandra_clearsnapshot:
-    keyspace: 
+    keyspace:
       - keyspace1
       - keyspace2
     name: 01-01-2024
@@ -80,15 +80,15 @@ from ansible_collections.community.cassandra.plugins.module_utils.cassandra_comm
 
 class NodeToolClearSnapshotCommand(NodeToolCmd):
 
-    """ 
-    Inherits from the NodeToolCmd class. Adds the following methods;     
-        - run_command 
-    """ 
-    def __init__(self, module, cmd): 
-        NodeToolCmd.__init__(self, module) 
+    """
+    Inherits from the NodeToolCmd class. Adds the following methods;
+        - run_command
+    """
+    def __init__(self, module, cmd):
+        NodeToolCmd.__init__(self, module)
         self.keyspace = module.params["keyspace"]
         self.name = module.params["name"]
-      
+
         if self.name is not None:
             cmd = "{0} -t {1}".format(cmd, self.name)
         else:
@@ -96,23 +96,23 @@ class NodeToolClearSnapshotCommand(NodeToolCmd):
         if self.keyspace is not None:
             cmd = "{0} {1}".format(cmd, " ".join(self.keyspace))
         self.cmd = cmd
- 
-    def run_command(self): 
-       return self.nodetool_cmd(self.cmd) 
+
+    def run_command(self):
+        return self.nodetool_cmd(self.cmd)
 
 
 def main():
     argument_spec = cassandra_common_argument_spec()
     argument_spec.update(
-        keyspace=dict(type='list', elements='str', default=None, required=False),
-        name=dict(type='str', default=None, aliases=['tag','t'], required=False),
+        keyspace=dict(type='list', elements='str', default=None, required=False, no_log=False),
+        name=dict(type='str', default=None, aliases=['tag', 't'], required=False),
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=False,
     )
-    
+
     cmd = "clearsnapshot"
 
     n = NodeToolClearSnapshotCommand(module, cmd)
@@ -121,7 +121,7 @@ def main():
     out = ''
     err = ''
     result = {}
-  
+
     (rc, out, err) = n.run_command()
     out = out.strip()
     err = err.strip()

--- a/plugins/modules/cassandra_clearsnapshot.py
+++ b/plugins/modules/cassandra_clearsnapshot.py
@@ -39,7 +39,6 @@ options:
       - Add additional debug to module output. 
     type: bool
     default: False 
-   
 '''
 
 EXAMPLES = '''
@@ -47,12 +46,16 @@ EXAMPLES = '''
   community.cassandra.cassandra_clearsnapshot:
 
 - name: Remove snapshots from multiple keyspaces on the node
-  community.cassandra.cassandra_snapshot:
-    keyspace: keyspace1, keyspace2
+  community.cassandra.cassandra_clearsnapshot:
+    keyspace: 
+      - keyspace1
+      - keyspace2
 
 - name: Remove all snapshots named 01-01-2024 from multiple keyspaces
-  community.cassandra.cassandra_snapshot:
-    keyspace: mykeyspace, mykeyspace_1
+  community.cassandra.cassandra_clearsnapshot:
+    keyspace: 
+      - keyspace1
+      - keyspace2
     name: 01-01-2024
 '''
 
@@ -88,10 +91,10 @@ class NodeToolClearSnapshotCommand(NodeToolCmd):
       
         if self.name is not None:
             cmd = "{0} -t {1}".format(cmd, self.name)
+        else:
+            cmd = "{0} --all".format(cmd)
         if self.keyspace is not None:
             cmd = "{0} {1}".format(cmd, " ".join(self.keyspace))
-        if self.name is None and self.keyspace is None:
-            cmd = "{0} --all".format(cmd)
         self.cmd = cmd
  
     def run_command(self): 
@@ -112,7 +115,7 @@ def main():
     
     cmd = "clearsnapshot"
 
-    n = NodeToolSnapshotCommand(module, cmd)
+    n = NodeToolClearSnapshotCommand(module, cmd)
 
     rc = None
     out = ''

--- a/plugins/modules/cassandra_snapshot.py
+++ b/plugins/modules/cassandra_snapshot.py
@@ -1,0 +1,187 @@
+#!/usr/bin/python
+
+# 2024 Jaymit Patel <18jaymit@gmail.com>
+# https://github.com/jaymitp
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+
+DOCUMENTATION = '''
+---
+module: cassandra_snapshot
+author: Jaymit Patel (@jaymitp)
+short_description: Take a snapshot of one or more keyspaces, or tables to backup data.
+requirements:
+  - nodetool
+description:
+    - Used to back up data using a snapshot.
+    - Take snapshots of keyspaces or tables.
+    - Optionally skip flushing the node before taking a snapshot
+
+extends_documentation_fragment:
+  - community.cassandra.nodetool_module_options
+
+options:
+  keyspace:
+    description:
+      - Optional keyspace to snapshot. Default: all keyspaces.
+    type: list
+    elements: str
+  table:
+    description:
+      - Optional table to snapshot. You must specify one and only one keyspace.
+    type: str
+  keyspace_table:
+    description:
+      - Optional keyspace.table to snapshot.
+    type: list
+    elements: str
+  name:
+    description:
+      - Name of the snapshot.
+    type: str
+    aliases:
+      - tag
+      - t
+  skip_flush:
+    description:
+      - Executes the snapshot without flushing the tables first
+    type: bool
+    default: False
+'''
+
+EXAMPLES = '''
+- name: Snapshot all keyspaces on the node
+  community.cassandra.cassandra_snapshot:
+
+- name: Snapshot multiple keyspaces on the node without flushing node
+  community.cassandra.cassandra_snapshot:
+    keyspace: keyspace1, keyspace2
+    skip_flush: true
+
+- name: Snapshot single keyspace with snapshot name 01-01-2024
+  community.cassandra.cassandra_snapshot:
+    keyspace: mykeyspace
+    name: 01-01-2024
+
+- name: Snapshot single table in a keyspace
+  community.cassandra.cassandra_snapshot:
+    keyspace: mykeyspace
+    table: mytable
+
+- name: Snapshot several tables in the same/different keyspaces
+  community.cassandra.cassandra_snapshot:
+    keyspace_table: mykeyspace.table, mykeyspace.table2, test.table1
+    name: test_backup
+'''
+
+RETURN = '''
+snapshot_dir:
+  description: Name of a snapshot directory.
+  returned: on success
+  type: str
+msg:
+  description: A message indicating what has happened.
+  returned: on success
+  type: str
+rc: 
+  description: Return code of the last executed command.
+  returned: always
+  type: int
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+__metaclass__ = type
+
+
+from ansible_collections.community.cassandra.plugins.module_utils.nodetool_cmd_objects import NodeToolCmd
+from ansible_collections.community.cassandra.plugins.module_utils.cassandra_common_options import cassandra_common_argument_spec
+
+
+class NodeToolSnapshotCommand(NodeToolCmd):
+
+    """ 
+    Inherits from the NodeToolCmd class. Adds the following methods;     
+        - run_command 
+    """ 
+    def __init__(self, module, cmd): 
+        NodeToolCmd.__init__(self, module) 
+        self.keyspace = module.params["keyspace"]
+        self.table = module.params["table"]
+        self.keyspace_table = module.params["keyspace_table"]
+        self.skip_flush = module.params["skip_flush"]
+        self.name = module.params["name"]
+      
+        if self.skip_flush:
+            cmd = "{0} -sf".format(cmd)
+        if self.name is not None:
+            cmd = "{0} -t {1}".format(cmd, self.name)
+        if self.table is not None:
+            cmd = "{0} -cf {1}".format(cmd, self.table)
+        if self.keyspace_table is not None:
+            if isinstance(self.keyspace_table, str):
+                cmd = "{0} -kt {1}".format(cmd, self.keyspace_table)
+            elif isinstance(self.keyspace_table, list):
+                cmd = "{0} -kt {1}".format(cmd, (",".join(self.keyspace_table)).replace(" ",""))
+        if self.keyspace is not None:
+            cmd = "{0} {1}".format(cmd, " ".join(self.keyspace))
+        self.cmd = cmd
+ 
+    def run_command(self): 
+       return self.nodetool_cmd(self.cmd) 
+
+
+def main():
+    argument_spec = cassandra_common_argument_spec()
+    argument_spec.update(
+        keyspace=dict(type='list', elements='str', default=None, required=False),
+        table=dict(type='raw', default=None, required=False),
+        keyspace_table=dict(type='list', elements='str', default=None, required=False),
+        skip_flush=dict(type='bool', default=False, aliases=['sf'], required=False),
+        name=dict(type='str', default=None, aliases=['tag','t'], required=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=False,     # Maybe, will need to make use of listsnapshots though
+    )
+    
+    cmd = "snapshot"
+
+    n = NodeToolSnapshotCommand(module, cmd)
+
+    rc = None
+    out = ''
+    err = ''
+    result = {}
+  
+    
+    #if table != None and len(keyspace) > 1:
+    #   module.fail_json(msg = "When specifying the table for a snapshot, you must specify one and only one keyspace")
+    #if keyspace_table != None and keyspace != None:
+    #   module.fail_json(msg = "When specifying the Keyspace table list, you must not also specify keyspaces to snapshot")
+   
+    (rc, out, err) = n.run_command()
+    out = out.strip()
+    err = err.strip()
+    if module.params['debug']:
+        if out:
+            result['stdout'] = out
+        if err:
+            result['stderr'] = err
+
+    if rc == 0:
+        result['changed'] = True
+        result['msg'] = "nodetool snapshot executed successfully"
+        result['snapshot_dir'] = out.split(" ")[-1]
+        module.exit_json(**result)
+    else:
+        result['rc'] = rc
+        result['changed'] = False
+        result['msg'] = "nodetool snapshot did not execute successfully"
+        module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/cassandra_snapshot.py
+++ b/plugins/modules/cassandra_snapshot.py
@@ -156,12 +156,6 @@ def main():
     err = ''
     result = {}
   
-    
-    #if table != None and len(keyspace) > 1:
-    #   module.fail_json(msg = "When specifying the table for a snapshot, you must specify one and only one keyspace")
-    #if keyspace_table != None and keyspace != None:
-    #   module.fail_json(msg = "When specifying the Keyspace table list, you must not also specify keyspaces to snapshot")
-   
     (rc, out, err) = n.run_command()
     out = out.strip()
     err = err.strip()

--- a/plugins/modules/cassandra_snapshot.py
+++ b/plugins/modules/cassandra_snapshot.py
@@ -25,13 +25,13 @@ extends_documentation_fragment:
 options:
   keyspace:
     description:
-      - Optional keyspace to snapshot. Default: all keyspaces.
+      - "Optional keyspace to snapshot. Default: all keyspaces."
     type: list
     elements: str
   table:
     description:
       - Optional table to snapshot. You must specify one and only one keyspace.
-    type: str
+    type: raw
   keyspace_table:
     description:
       - Optional keyspace.table to snapshot.
@@ -48,6 +48,8 @@ options:
     description:
       - Executes the snapshot without flushing the tables first
     type: bool
+    aliases:
+      - sf
     default: False
 '''
 
@@ -85,7 +87,7 @@ msg:
   description: A message indicating what has happened.
   returned: on success
   type: str
-rc: 
+rc:
   description: Return code of the last executed command.
   returned: always
   type: int
@@ -101,18 +103,18 @@ from ansible_collections.community.cassandra.plugins.module_utils.cassandra_comm
 
 class NodeToolSnapshotCommand(NodeToolCmd):
 
-    """ 
-    Inherits from the NodeToolCmd class. Adds the following methods;     
-        - run_command 
-    """ 
-    def __init__(self, module, cmd): 
-        NodeToolCmd.__init__(self, module) 
+    """
+    Inherits from the NodeToolCmd class. Adds the following methods;
+        - run_command
+    """
+    def __init__(self, module, cmd):
+        NodeToolCmd.__init__(self, module)
         self.keyspace = module.params["keyspace"]
         self.table = module.params["table"]
         self.keyspace_table = module.params["keyspace_table"]
         self.skip_flush = module.params["skip_flush"]
         self.name = module.params["name"]
-      
+
         if self.skip_flush:
             cmd = "{0} -sf".format(cmd)
         if self.name is not None:
@@ -123,30 +125,30 @@ class NodeToolSnapshotCommand(NodeToolCmd):
             if isinstance(self.keyspace_table, str):
                 cmd = "{0} -kt {1}".format(cmd, self.keyspace_table)
             elif isinstance(self.keyspace_table, list):
-                cmd = "{0} -kt {1}".format(cmd, (",".join(self.keyspace_table)).replace(" ",""))
+                cmd = "{0} -kt {1}".format(cmd, (",".join(self.keyspace_table)).replace(" ", ""))
         if self.keyspace is not None:
             cmd = "{0} {1}".format(cmd, " ".join(self.keyspace))
         self.cmd = cmd
- 
-    def run_command(self): 
-       return self.nodetool_cmd(self.cmd) 
+
+    def run_command(self):
+        return self.nodetool_cmd(self.cmd)
 
 
 def main():
     argument_spec = cassandra_common_argument_spec()
     argument_spec.update(
-        keyspace=dict(type='list', elements='str', default=None, required=False),
+        keyspace=dict(type='list', elements='str', default=None, required=False, no_log=False),
         table=dict(type='raw', default=None, required=False),
-        keyspace_table=dict(type='list', elements='str', default=None, required=False),
+        keyspace_table=dict(type='list', elements='str', default=None, required=False, no_log=False),
         skip_flush=dict(type='bool', default=False, aliases=['sf'], required=False),
-        name=dict(type='str', default=None, aliases=['tag','t'], required=False),
+        name=dict(type='str', default=None, aliases=['tag', 't'], required=False),
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=False,     # Maybe, will need to make use of listsnapshots though
     )
-    
+
     cmd = "snapshot"
 
     n = NodeToolSnapshotCommand(module, cmd)
@@ -155,7 +157,7 @@ def main():
     out = ''
     err = ''
     result = {}
-  
+
     (rc, out, err) = n.run_command()
     out = out.strip()
     err = err.strip()

--- a/tests/integration/targets/cassandra_clearsnapshot/meta/main.yml
+++ b/tests/integration/targets/cassandra_clearsnapshot/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_cassandra

--- a/tests/integration/targets/cassandra_clearsnapshot/tasks/main.yml
+++ b/tests/integration/targets/cassandra_clearsnapshot/tasks/main.yml
@@ -1,0 +1,78 @@
+# test code for the cassandra_clearsnapshot module
+# (c) 2024, Jaymit Patel <18jaymit@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ===========================================================
+
+# Tagged snapshot does not need to exist for clearsnapshot to return successful
+
+- name: Clear snapshots named test_backup from specific keyspaces
+  community.cassandra.cassandra_clearsnapshot:
+    name: test_backup
+    keyspace:
+      - system_auth
+      - system_traces
+    debug: true
+  register: result
+  
+- assert:
+    that:
+    - result.changed
+    - "result.msg == 'nodetool clearsnapshot executed successfully'"
+    - "result.stdout is search('[system_auth, system_traces]')"
+    - "result.stdout is search('[test_backup]')"
+
+- name: Clear all snapshots from specific keyspaces
+  community.cassandra.cassandra_clearsnapshot:
+    keyspace: 
+      - system_auth
+      - system_traces
+    debug: true
+  register: result
+
+- assert:
+    that:
+    - result.changed
+    - "result.msg == 'nodetool clearsnapshot executed successfully'"
+    - "result.stdout is search('[system_auth, system_traces]')"
+    - "result.stdout is search('[all snapshots]')"
+
+
+- name: Clear snapshot named test_backup2 from all keyspaces
+  community.cassandra.cassandra_clearsnapshot:
+    name: test_backup2
+    debug: true
+  register: result
+
+- assert:
+    that:
+    - result.changed
+    - "result.msg == 'nodetool clearsnapshot executed successfully'"
+    - "result.stdout is search('[all keyspaces]')"
+    - "result.stdout is search('[test_backup2]')"
+    
+- name: Clear snapshots from all keyspaces on the node
+  community.cassandra.cassandra_clearsnapshot:
+    debug: true
+  register: result
+
+- assert:
+    that:
+    - result.changed
+    - "result.msg == 'nodetool clearsnapshot executed successfully'"
+    - "result.stdout is search('[all keyspaces]')"
+    - "result.stdout is search('[all snapshots]')"

--- a/tests/integration/targets/cassandra_clearsnapshot/tasks/main.yml
+++ b/tests/integration/targets/cassandra_clearsnapshot/tasks/main.yml
@@ -28,17 +28,17 @@
       - system_traces
     debug: true
   register: result
-  
+
 - assert:
     that:
-    - result.changed
-    - "result.msg == 'nodetool clearsnapshot executed successfully'"
-    - "result.stdout is search('[system_auth, system_traces]')"
-    - "result.stdout is search('[test_backup]')"
+      - result.changed
+      - "result.msg == 'nodetool clearsnapshot executed successfully'"
+      - "result.stdout is search('[system_auth, system_traces]')"
+      - "result.stdout is search('[test_backup]')"
 
 - name: Clear all snapshots from specific keyspaces
   community.cassandra.cassandra_clearsnapshot:
-    keyspace: 
+    keyspace:
       - system_auth
       - system_traces
     debug: true
@@ -46,11 +46,10 @@
 
 - assert:
     that:
-    - result.changed
-    - "result.msg == 'nodetool clearsnapshot executed successfully'"
-    - "result.stdout is search('[system_auth, system_traces]')"
-    - "result.stdout is search('[all snapshots]')"
-
+      - result.changed
+      - "result.msg == 'nodetool clearsnapshot executed successfully'"
+      - "result.stdout is search('[system_auth, system_traces]')"
+      - "result.stdout is search('[all snapshots]')"
 
 - name: Clear snapshot named test_backup2 from all keyspaces
   community.cassandra.cassandra_clearsnapshot:
@@ -60,11 +59,11 @@
 
 - assert:
     that:
-    - result.changed
-    - "result.msg == 'nodetool clearsnapshot executed successfully'"
-    - "result.stdout is search('[all keyspaces]')"
-    - "result.stdout is search('[test_backup2]')"
-    
+      - result.changed
+      - "result.msg == 'nodetool clearsnapshot executed successfully'"
+      - "result.stdout is search('[all keyspaces]')"
+      - "result.stdout is search('[test_backup2]')"
+
 - name: Clear snapshots from all keyspaces on the node
   community.cassandra.cassandra_clearsnapshot:
     debug: true
@@ -72,7 +71,7 @@
 
 - assert:
     that:
-    - result.changed
-    - "result.msg == 'nodetool clearsnapshot executed successfully'"
-    - "result.stdout is search('[all keyspaces]')"
-    - "result.stdout is search('[all snapshots]')"
+      - result.changed
+      - "result.msg == 'nodetool clearsnapshot executed successfully'"
+      - "result.stdout is search('[all keyspaces]')"
+      - "result.stdout is search('[all snapshots]')"

--- a/tests/integration/targets/cassandra_clearsnapshot/vars/main.yml
+++ b/tests/integration/targets/cassandra_clearsnapshot/vars/main.yml
@@ -1,0 +1,1 @@
+cassandra_auth_tests: True

--- a/tests/integration/targets/cassandra_snapshot/meta/main.yml
+++ b/tests/integration/targets/cassandra_snapshot/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_cassandra

--- a/tests/integration/targets/cassandra_snapshot/tasks/main.yml
+++ b/tests/integration/targets/cassandra_snapshot/tasks/main.yml
@@ -1,0 +1,147 @@
+# test code for the cassandra_snapshot module
+# (c) 2024, Jaymit Patel <18jaymit@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ===========================================================
+- name: Set shell nodetool command
+  set_fact:
+    nodetool_cmd: nodetool -h127.0.0.1
+
+- name: List snapshots to ensure there are no snapshots
+  shell: "{{ nodetool_cmd }} listsnapshots" 
+  register: snapshot_list
+
+- name: Clear snapshots
+  shell: "{{ nodetool_cmd }} clearsnapshot --all"
+  when: snapshot_list.stdout is search("There are no snapshots")
+
+- name: Snapshot all keyspaces on the node
+  community.cassandra.cassandra_snapshot:
+    debug: true
+  register: snapshot
+  
+- assert:
+    that:
+    - snapshot.changed
+    - "snapshot.msg == 'nodetool snapshot executed successfully'"
+    - "snapshot.snapshot_dir | length == 13" # Verify the correct dir is returned, default tag is a unix timestamp w/ ms
+    - "snapshot.stdout is search('all keyspaces')"
+
+- name: Snapshot multiple keyspaces on the node without flushing node
+  community.cassandra.cassandra_snapshot:
+    keyspace: system_auth, system_traces
+    skip_flush: true
+    debug: true
+  register: snapshot
+
+- assert:
+    that:
+    - snapshot.changed
+    - "snapshot.msg == 'nodetool snapshot executed successfully'"
+    - "snapshot.stdout is search('skipFlush=true')"
+    - "snapshot.stdout is search('[system_auth, system_traces]')"
+
+- name: Snapshot single keyspace with snapshot name 01-01-2024
+  community.cassandra.cassandra_snapshot:
+    keyspace: system_auth
+    name: 01-01-2024
+  register: snapshot
+
+- assert:
+    that:
+    - snapshot.changed
+    - "snapshot.msg == 'nodetool snapshot executed successfully'"
+    - "snapshot.snapshot_dir == '01-01-2024'"
+    
+- name: Snapshot single table in a keyspace
+  community.cassandra.cassandra_snapshot:
+    keyspace: system_auth
+    table: roles
+    debug: true
+  register: snapshot
+
+- assert:
+    that:
+    - snapshot.changed
+    - "snapshot.msg == 'nodetool snapshot executed successfully'"
+    - "snapshot.stdout is search('[system_auth.roles]')"
+
+- name: Snapshot several tables in the same/different keyspaces
+  community.cassandra.cassandra_snapshot:
+    keyspace_table: system_auth.roles, system_auth.role_members, system_schema.tables
+    tag: test_backup # alias for name
+    debug: true
+  register: snapshot
+
+- assert:
+    that:
+    - snapshot.changed
+    - "snapshot.msg == 'nodetool snapshot executed successfully'"
+    - "snapshot.snapshot_dir == 'test_backup'"
+    - "snapshot.stdout is search('[mykeyspace.table, mykeyspace.table2, test.table1]')"
+
+
+# Errorneous
+
+- name: Snapshot with tag that already exists
+  community.cassandra.cassandra_snapshot:
+    name: test_backup
+    debug: true
+  register: snapshot_failed
+  ignore_errors: true
+
+- assert:
+    that:
+    - not snapshot_failed.changed
+    - "snapshot_failed.msg == 'nodetool snapshot did not execute successfully'"
+    - "snapshot_failed.stderr is search('Snapshot.*already exists')"
+
+- name: Snapshot with table and multiple keyspaces
+  community.cassandra.cassandra_snapshot:
+    table: roles
+    keyspace: 
+      - system_auth
+      - system_traces
+    debug: true
+  register: snapshot_failed
+  ignore_errors: true
+
+- assert:
+    that:
+    - not snapshot_failed.changed
+    - "snapshot_failed.msg == 'nodetool snapshot did not execute successfully'"
+    - "snapshot_failed.stderr is search('must specify one and only one keyspace')"
+
+- name: Snapshot with keyspace.table supplied and multiple keyspaces
+  community.cassandra.cassandra_snapshot:
+    keyspace_table: system_auth.roles
+    keyspace:
+      - system_auth
+      - system_traces
+    debug: true
+  register: snapshot_failed
+  ignore_errors: true
+
+- assert:
+    that:
+    - not snapshot_failed.changed
+    - "snapshot_failed.msg == 'nodetool snapshot did not execute successfully'"
+    - "snapshot_failed.stderr is search('you must not also specify keyspaces to snapshot')"
+
+
+- name: Clean snapshots
+  shell: "{{ nodetool_cmd }} clearsnapshot --all"

--- a/tests/integration/targets/cassandra_snapshot/tasks/main.yml
+++ b/tests/integration/targets/cassandra_snapshot/tasks/main.yml
@@ -22,7 +22,7 @@
     nodetool_cmd: nodetool -h127.0.0.1
 
 - name: List snapshots to ensure there are no snapshots
-  shell: "{{ nodetool_cmd }} listsnapshots" 
+  shell: "{{ nodetool_cmd }} listsnapshots"
   register: snapshot_list
 
 - name: Clear snapshots
@@ -33,13 +33,13 @@
   community.cassandra.cassandra_snapshot:
     debug: true
   register: snapshot
-  
+
 - assert:
     that:
-    - snapshot.changed
-    - "snapshot.msg == 'nodetool snapshot executed successfully'"
-    - "snapshot.snapshot_dir | length == 13" # Verify the correct dir is returned, default tag is a unix timestamp w/ ms
-    - "snapshot.stdout is search('all keyspaces')"
+      - snapshot.changed
+      - "snapshot.msg == 'nodetool snapshot executed successfully'"
+      - "snapshot.snapshot_dir | length == 13" # Verify the correct dir is returned, default tag is a unix timestamp w/ ms
+      - "snapshot.stdout is search('all keyspaces')"
 
 - name: Snapshot multiple keyspaces on the node without flushing node
   community.cassandra.cassandra_snapshot:
@@ -50,23 +50,27 @@
 
 - assert:
     that:
-    - snapshot.changed
-    - "snapshot.msg == 'nodetool snapshot executed successfully'"
-    - "snapshot.stdout is search('skipFlush=true')"
-    - "snapshot.stdout is search('[system_auth, system_traces]')"
+      - snapshot.changed
+      - "snapshot.msg == 'nodetool snapshot executed successfully'"
+      - "snapshot.stdout is search('skipFlush=true')"
+      - "snapshot.stdout is search('[system_auth, system_traces]')"
 
 - name: Snapshot single keyspace with snapshot name 01-01-2024
   community.cassandra.cassandra_snapshot:
     keyspace: system_auth
     name: 01-01-2024
+    debug: true
   register: snapshot
+
+- debug:
+    var: snapshot
 
 - assert:
     that:
-    - snapshot.changed
-    - "snapshot.msg == 'nodetool snapshot executed successfully'"
-    - "snapshot.snapshot_dir == '01-01-2024'"
-    
+      - snapshot.changed
+      - "snapshot.msg == 'nodetool snapshot executed successfully'"
+      - "snapshot.snapshot_dir == '01-01-2024'"
+
 - name: Snapshot single table in a keyspace
   community.cassandra.cassandra_snapshot:
     keyspace: system_auth
@@ -76,9 +80,9 @@
 
 - assert:
     that:
-    - snapshot.changed
-    - "snapshot.msg == 'nodetool snapshot executed successfully'"
-    - "snapshot.stdout is search('[system_auth.roles]')"
+      - snapshot.changed
+      - "snapshot.msg == 'nodetool snapshot executed successfully'"
+      - "snapshot.stdout is search('[system_auth.roles]')"
 
 - name: Snapshot several tables in the same/different keyspaces
   community.cassandra.cassandra_snapshot:
@@ -89,11 +93,10 @@
 
 - assert:
     that:
-    - snapshot.changed
-    - "snapshot.msg == 'nodetool snapshot executed successfully'"
-    - "snapshot.snapshot_dir == 'test_backup'"
-    - "snapshot.stdout is search('[mykeyspace.table, mykeyspace.table2, test.table1]')"
-
+      - snapshot.changed
+      - "snapshot.msg == 'nodetool snapshot executed successfully'"
+      - "snapshot.snapshot_dir == 'test_backup'"
+      - "snapshot.stdout is search('[mykeyspace.table, mykeyspace.table2, test.table1]')"
 
 # Errorneous
 
@@ -106,14 +109,14 @@
 
 - assert:
     that:
-    - not snapshot_failed.changed
-    - "snapshot_failed.msg == 'nodetool snapshot did not execute successfully'"
-    - "snapshot_failed.stderr is search('Snapshot.*already exists')"
+      - not snapshot_failed.changed
+      - "snapshot_failed.msg == 'nodetool snapshot did not execute successfully'"
+      - "snapshot_failed.stderr is search('Snapshot.*already exists')"
 
 - name: Snapshot with table and multiple keyspaces
   community.cassandra.cassandra_snapshot:
     table: roles
-    keyspace: 
+    keyspace:
       - system_auth
       - system_traces
     debug: true
@@ -122,9 +125,9 @@
 
 - assert:
     that:
-    - not snapshot_failed.changed
-    - "snapshot_failed.msg == 'nodetool snapshot did not execute successfully'"
-    - "snapshot_failed.stderr is search('must specify one and only one keyspace')"
+      - not snapshot_failed.changed
+      - "snapshot_failed.msg == 'nodetool snapshot did not execute successfully'"
+      - "snapshot_failed.stderr is search('must specify one and only one keyspace')"
 
 - name: Snapshot with keyspace.table supplied and multiple keyspaces
   community.cassandra.cassandra_snapshot:
@@ -138,10 +141,9 @@
 
 - assert:
     that:
-    - not snapshot_failed.changed
-    - "snapshot_failed.msg == 'nodetool snapshot did not execute successfully'"
-    - "snapshot_failed.stderr is search('you must not also specify keyspaces to snapshot')"
-
+      - not snapshot_failed.changed
+      - "snapshot_failed.msg == 'nodetool snapshot did not execute successfully'"
+      - "snapshot_failed.stderr is search('When specifying the Keyspace')"
 
 - name: Clean snapshots
   shell: "{{ nodetool_cmd }} clearsnapshot --all"

--- a/tests/integration/targets/cassandra_snapshot/vars/main.yml
+++ b/tests/integration/targets/cassandra_snapshot/vars/main.yml
@@ -1,0 +1,1 @@
+cassandra_auth_tests: True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hi, thought I would implement the snapshot functionality since it was something I was looking for. 
I saw in #279 that it was a module of interest as well and I am learning to create ansible modules.
I have of course included integration tests 😄
Do let me know if anything should be changed/improved.

Some caveats:
- A check mode could be added easily using listsnapshot (I could definitely do so)
- Merging both snapshot and clearsnapshot into a single module is possible by making use of a 'present/state' variable, but is messy.
- Nodetool requests for a snapshot to be created/removed, so although the command is run successfully, changes may not be made...

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cassandra_snapshot
cassandra_clearsnapshot
