### PR TITLE
Added cassandra_exact_version var

### DIFF
--- a/roles/cassandra_install/defaults/main.yml
+++ b/roles/cassandra_install/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for cassandra_install
 cassandra_packages: cassandra
+cassandra_exact_version: 3.11.17

--- a/roles/cassandra_install/tasks/main.yml
+++ b/roles/cassandra_install/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Install Cassandra Packages
   package:
-    name: "{{ cassandra_packages }}"
+    name: "{{ cassandra_packages }}={{ cassandra_exact_version }}"
     state: present
   retries: 3
 


### PR DESCRIPTION
##### SUMMARY
Added the `cassandra_exact_version` variable to allow specifying the exact version of Cassandra to install. This change ensures that the desired version can be installed, which is particularly useful during upgrades of existing installations on Debian.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cassandra_install

##### ADDITIONAL INFORMATION
This update modifies the `cassandra_install` role to support specifying an exact version of Cassandra for installation. The change affects the `defaults/main.yml` and `tasks/main.yml` files. By using the `cassandra_exact_version` variable, users can control the installed version during upgrades or initial setups.

Example usage in an inventory file:
```ini
[c502_nodes]
c1_502 cassandra_version="50x" cassandra_exact_version="5.0.2"

