### PR TITLE
New add key method

### DIFF
--- a/roles/cassandra_firewall/molecule/default/molecule.yml
+++ b/roles/cassandra_firewall/molecule/default/molecule.yml
@@ -21,6 +21,10 @@ platforms:
     image: ubuntu:18.04
     command: /sbin/init
     privileged: True
+  - name: ubuntu_20
+    image: ubuntu:20.04
+    command: /sbin/init
+    privileged: True
  # - name: debian_buster
  #   image: debian:buster
  #   command: /sbin/init

--- a/roles/cassandra_install/molecule/default/molecule.yml
+++ b/roles/cassandra_install/molecule/default/molecule.yml
@@ -11,10 +11,10 @@ lint:
 platforms:
   #- name: centos_7
   #  image: centos:7
-  - name: ubuntu_16
-    image: ubuntu:16.04
-  - name: ubuntu_18
-    image: ubuntu:18.04
+  #- name: ubuntu_16
+  #  image: ubuntu:16.04
+  - name: ubuntu_20
+    image: ubuntu:20.04
   #- name: debian_buster
   #  image: debian:buster
   #- name: debian_stretch

--- a/roles/cassandra_linux/molecule/default/molecule.yml
+++ b/roles/cassandra_linux/molecule/default/molecule.yml
@@ -21,6 +21,10 @@ platforms:
     image: ubuntu:18.04
     command: /sbin/init
     privileged: True
+  - name: ubuntu_20
+    image: ubuntu:20.04
+    command: /sbin/init
+    privileged: True
   - name: debian_buster
     image: debian:buster
     command: /sbin/init

--- a/roles/cassandra_repository/molecule/default/molecule.yml
+++ b/roles/cassandra_repository/molecule/default/molecule.yml
@@ -15,6 +15,8 @@ platforms:
     image: ubuntu:16.04
   - name: ubuntu_18
     image: ubuntu:18.04
+  - name: ubuntu_20
+    image: ubuntu:20.04
   - name: debian_buster
     image: debian:buster
   #- name: debian_stretch

--- a/roles/cassandra_repository/molecule/default/playbook.yml
+++ b/roles/cassandra_repository/molecule/default/playbook.yml
@@ -1,5 +1,6 @@
 ---
 - name: Converge
   hosts: all
+  strategy: debug
   roles:
     - role: cassandra_repository

--- a/roles/cassandra_repository/tasks/main.yml
+++ b/roles/cassandra_repository/tasks/main.yml
@@ -28,7 +28,8 @@
 - name: Add apt key for Cassandra repository (Debian & Ubuntu)
   ansible.builtin.shell: |
     mkdir -p /etc/apt/keyrings/ && \
-    curl -o /etc/apt/keyrings/apache-cassandra.asc https://downloads.apache.org/cassandra/KEYS
+    curl -o /etc/apt/keyrings/apache-cassandra.asc https://downloads.apache.org/cassandra/KEYS && \
+    apt update
   args:
     creates: /etc/apt/keyrings/apache-cassandra.asc
   retries: 3

--- a/roles/cassandra_repository/tasks/main.yml
+++ b/roles/cassandra_repository/tasks/main.yml
@@ -26,9 +26,9 @@
 
 
 - name: Add apt key for Cassandra repository (Debian & Ubuntu)
-  apt_key:
-    url: https://downloads.apache.org/cassandra/KEYS
-    state: present
+  ansible.builtin.shell: curl -o /etc/apt/keyrings/apache-cassandra.asc https://downloads.apache.org/cassandra/KEYS
+  args:
+    creates: /etc/apt/keyrings/apache-cassandra.asc
   retries: 3
   when: ansible_os_family == "Debian"
 

--- a/roles/cassandra_repository/tasks/main.yml
+++ b/roles/cassandra_repository/tasks/main.yml
@@ -26,7 +26,9 @@
 
 
 - name: Add apt key for Cassandra repository (Debian & Ubuntu)
-  ansible.builtin.shell: curl -o /etc/apt/keyrings/apache-cassandra.asc https://downloads.apache.org/cassandra/KEYS
+  ansible.builtin.shell: |
+    mkdir -p /etc/apt/keyrings/ && \
+    curl -o /etc/apt/keyrings/apache-cassandra.asc https://downloads.apache.org/cassandra/KEYS
   args:
     creates: /etc/apt/keyrings/apache-cassandra.asc
   retries: 3


### PR DESCRIPTION
##### SUMMARY
Should fix this issue...

   TASK [cassandra_repository : Add apt key for Cassandra repository (Debian & Ubuntu)] ***
    fatal: [ubuntu_16]: FAILED! => {"changed": false, "cmd": "/usr/bin/apt-key add -", "msg": "gpg: key C588E28D: no valid user IDs", "rc": 2, "stderr": "gpg: key C588E28D: no valid user IDs\n", "stderr_lines": ["gpg: key C588E28D: no valid user IDs"], "stdout": "", "stdout_lines": []}
    changed: [ubuntu_18]

Might need to add an apt update after this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cassandra_repository
