### PR TITLE
Fix CCM Java 8 issue for Cassandra 3.11 CI (#304)

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -108,6 +108,12 @@ jobs:
         with:
           python-version: ${{ matrix.versions.python_version }}
 
+      - name: Set up Java 8 for Cassandra 3.11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+
       - name: Install ansible-base (${{ matrix.versions.ansible_version }})
         uses: nick-invision/retry@v3
         with:


### PR DESCRIPTION
SUMMARY

Fixes #304 - Install Java 8 in the integration_311x CI job to fix CCM startup failure on Cassandra 3.11. Cassandra 3.11 requires Java 8, but the ubuntu-24.04 runner only has Java 11 available, causing CCM to raise a RuntimeError when attempting to start the cluster.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

.github/workflows/ansible-test.yml

ADDITIONAL INFORMATION

Cassandra 3.11 only supports Java 8 in CCM it seems. The CI runner (ubuntu-24.04) ships with Java 11 only, which causes CCM to fail with:

```
RuntimeError: london1: Cannot find any Java distribution for the current invocation.
Available Java distributions: {11: 'JAVA_HOME'}, required Java distributions: [8]
```


The fix adds a actions/setup-java@v4 step with java-version: '8' (Temurin distribution) specifically in the integration_311x job, before CCM starts.