### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -95,9 +95,6 @@ jobs:
           - docker_image: "default"
             python_version: "3.10"
             ansible_test_options: ""
-          - docker_image: centos7
-            python_version: "2.7"
-            ansible_test_options: "--docker-privileged"
         cassandra_module: ${{ fromJson(needs.integration_matrix.outputs.matrix) }}
     steps:
       - name: Check out code

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -8,8 +8,6 @@ env:
   setup_cassandra_version_file: "./tests/integration/targets/setup_cassandra/defaults/main.yml"
   setup_ccm_version_file: "./tests/integration/targets/setup_cassandra_cluster_manager/defaults/main.yml"
 
-# Some of the software used in these tests, e.g. ccm and csqlsh requires the six library and this 
-# breaks on anything over python 3.10, so we hardcode this python version in ansible-test commands
 jobs:
   sanity:
     runs-on: ubuntu-24.04
@@ -198,7 +196,7 @@ jobs:
           sed -i 's/^cassandra_version:.*/cassandra_version: \"${{ matrix.cassandra_version.tar_version }}\"/g' ${{ env.setup_ccm_version_file }}
 
       - name: Run integration tests on Python ${{ matrix.test_scenario.python_version }} | ${{ matrix.test_scenario.docker_image }} | ${{ matrix.versions.ansible_version }} | ${{ matrix.cassandra_module }} | ${{ matrix.cassandra_version.package_version }}
-        run: ansible-test integration --docker ${{ matrix.test_scenario.docker_image }} ${{ matrix.test_scenario.ansible_test_options }} -v --color --retry-on-error --python 3.10 --continue-on-error --diff --coverage  ${{ matrix.cassandra_module }}
+        run: ansible-test integration --docker ${{ matrix.test_scenario.docker_image }} ${{ matrix.test_scenario.ansible_test_options }} -v --color --retry-on-error --python ${{ matrix.test_scenario.python_version }} --continue-on-error --diff --coverage  ${{ matrix.cassandra_module }}
 
       - name: Generate coverage report.
         run: ansible-test coverage xml -v --requirements --group-by command --group-by version
@@ -269,7 +267,7 @@ jobs:
           sed -i 's/^cassandra_version:.*/cassandra_version: \"${{ matrix.cassandra_version.tar_version }}\"/g' ${{ env.setup_ccm_version_file }}
 
       - name: Run integration tests on Python ${{ matrix.test_scenario.python_version }} | ${{ matrix.test_scenario.docker_image }} | ${{ matrix.versions.ansible_version }} | ${{ matrix.cassandra_module }} | ${{ matrix.cassandra_version.package_version }}
-        run: ansible-test integration --docker ${{ matrix.test_scenario.docker_image }} ${{ matrix.test_scenario.ansible_test_options }} -v --color --retry-on-error --python 3.10 --continue-on-error --diff --coverage  ${{ matrix.cassandra_module }}
+        run: ansible-test integration --docker ${{ matrix.test_scenario.docker_image }} ${{ matrix.test_scenario.ansible_test_options }} -v --color --retry-on-error --python ${{ matrix.test_scenario.python_version }} --continue-on-error --diff --coverage  ${{ matrix.cassandra_module }}
 
       - name: Generate coverage report.
         run: ansible-test coverage xml -v --requirements --group-by command --group-by version

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -130,7 +130,7 @@ jobs:
           command: ansible-galaxy collection install ansible.posix -p ansible_collections/
 
       - name: Run integration tests on Python ${{ matrix.test_scenario.python_version }} | ${{ matrix.test_scenario.docker_image }} | ${{ matrix.versions.ansible_version }} | ${{ matrix.cassandra_module }} | ${{ matrix.cassandra_version.package_version }}
-        run: ansible-test integration --docker ${{ matrix.test_scenario.docker_image }} ${{ matrix.test_scenario.ansible_test_options }} -v --color --retry-on-error --python 3.8 --continue-on-error --diff --coverage  ${{ matrix.cassandra_module }}
+        run: ansible-test integration --docker ${{ matrix.test_scenario.docker_image }} ${{ matrix.test_scenario.ansible_test_options }} -v --color --retry-on-error --python ${{ matrix.test_scenario.python_version }} --continue-on-error --diff --coverage  ${{ matrix.cassandra_module }}
 
       - name: Generate coverage report.
         run: ansible-test coverage xml -v --requirements --group-by command --group-by version

--- a/tests/integration/targets/cassandra_ssl/tasks/main.yml
+++ b/tests/integration/targets/cassandra_ssl/tasks/main.yml
@@ -115,6 +115,17 @@
     dest: /home/cassandra/config/test/{{ item.node }}/conf/cassandra-rackdc.properties
   with_items: "{{ cassandra_nodes }}"
 
+- name: Cap JVM heap for CI runners via cassandra-env.sh
+  ansible.builtin.blockinfile:
+    path: "/home/cassandra/config/ssl-test-cluster/{{ item.node }}/conf/cassandra-env.sh"
+    marker: "# {mark} CI JVM HEAP SETTINGS"
+    block: |
+      MAX_HEAP_SIZE="256M"
+      HEAP_NEWSIZE="256M"
+    owner: cassandra
+    group: cassandra
+  with_items: "{{ cassandra_nodes }}"
+
 - set_fact:
     cassandra_node_delay: 120
   when: ansible_os_family == "RedHat"
@@ -447,6 +458,17 @@
       dc={{ item.dc }}
       rack=rack1
     dest: /home/cassandra/config/test/{{ item.node }}/conf/cassandra-rackdc.properties
+  with_items: "{{ cassandra_nodes }}"
+
+- name: Cap JVM heap for CI runners via cassandra-env.sh
+  ansible.builtin.blockinfile:
+    path: "/home/cassandra/config/ssl-test-cluster-auth/{{ item.node }}/conf/cassandra-env.sh"
+    marker: "# {mark} CI JVM HEAP SETTINGS"
+    block: |
+      MAX_HEAP_SIZE="256M"
+      HEAP_NEWSIZE="256M"
+    owner: cassandra
+    group: cassandra
   with_items: "{{ cassandra_nodes }}"
 
 - set_fact:

--- a/tests/integration/targets/cassandra_ssl/tasks/main.yml
+++ b/tests/integration/targets/cassandra_ssl/tasks/main.yml
@@ -140,7 +140,8 @@
     CASSANDRA_HOME: "/home/cassandra"
     JAVA_TOOL_OPTIONS: "-Dcom.sun.jndi.rmiURLParsing=legacy"
     PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/ant/bin
-    CCM_CLUSTER_START_DEFAULT_TIMEOUT: 600      
+    CCM_CLUSTER_START_DEFAULT_TIMEOUT: 600
+    JAVA_HOME: "{{ (ansible_os_family == 'RedHat') | ternary('/usr/lib/jvm/java-' ~ j_version ~ '-openjdk', '/usr/lib/jvm/java-' ~ j_version ~ '-openjdk-amd64') }}"
 
 - name: Get cluster status
   shell: sudo -E -u cassandra bash -c "{{ ccm_cmd }} status"
@@ -485,7 +486,8 @@
     CASSANDRA_HOME: "/home/cassandra"
     JAVA_TOOL_OPTIONS: "-Dcom.sun.jndi.rmiURLParsing=legacy"
     PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/ant/bin
-    CCM_CLUSTER_START_DEFAULT_TIMEOUT: 600    
+    CCM_CLUSTER_START_DEFAULT_TIMEOUT: 600
+    JAVA_HOME: "{{ (ansible_os_family == 'RedHat') | ternary('/usr/lib/jvm/java-' ~ j_version ~ '-openjdk', '/usr/lib/jvm/java-' ~ j_version ~ '-openjdk-amd64') }}"
 
 - name: Get cluster status
   shell: sudo -E -u cassandra bash -c "{{ ccm_cmd }} status"

--- a/tests/integration/targets/cassandra_status/tasks/main.yml
+++ b/tests/integration/targets/cassandra_status/tasks/main.yml
@@ -76,13 +76,15 @@
           - "'127.0.0.8' not in rhys.cluster_status['marlow']['up']"
 
     - name: Start node2
-      ansible.builtin.shell: "sudo -E -u cassandra bash -c \"{{ ccm_cmd | mandatory }} marlow1 start &\""
+      ansible.builtin.shell: "sudo -E -u cassandra bash -c \"{{ ccm_cmd | mandatory }} marlow1 start\""
       become_user: cassandra
       args:
         chdir: /home/cassandra
       environment:
         CCM_CONFIG_DIR: "/home/cassandra/config"
         CASSANDRA_HOME: "/home/cassandra"
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/ant/bin
+        JAVA_HOME: "{{ (ansible_os_family == 'RedHat') | ternary('/usr/lib/jvm/java-' ~ j_version ~ '-openjdk', '/usr/lib/jvm/java-' ~ j_version ~ '-openjdk-amd64') }}"
 
     # We expect marlow1 to rejoin the cluster
     - name: Execute module after marlow1 started again

--- a/tests/integration/targets/setup_cassandra/defaults/main.yml
+++ b/tests/integration/targets/setup_cassandra/defaults/main.yml
@@ -29,6 +29,18 @@ cassandra_authorizer: "authorizer: CassandraAuthorizer"
 cassandra_admin_user: cassandra
 cassandra_admin_pwd: cassandra
 
+# 3.11/4.0 use _in_ms integer keys; 4.1+ use duration-string keys.
+# cassandra_version is set by the test matrix: "311x", "40x", "41x", etc.
+cassandra_credentials_validity_line: >-
+  {{ 'credentials_validity_in_ms: 0'
+     if cassandra_version in ['311x', '40x']
+     else 'credentials_validity: 0ms' }}
+
+cassandra_credentials_update_interval_line: >-
+  {{ 'credentials_update_interval_in_ms: 0'
+     if cassandra_version in ['311x', '40x']
+     else 'credentials_update_interval: 0ms' }}
+
 # Generic Linux Packages
 required_packages:
   - "net-tools"

--- a/tests/integration/targets/setup_cassandra/tasks/cassandra_auth.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/cassandra_auth.yml
@@ -32,13 +32,17 @@
     line: "{{ cassandra_authorizer}}"
   no_log: yes
 
-# Should be replaced by 'nodetool invalidatecredentialscache' in 4.1+
 - name: Disable credential cache
   lineinfile:
     path: "{{ cassandra_yml_file }}"
     regexp: "^credentials_validity"
-    line: 'credentials_validity_in_ms: 0'
+    line: "{{ cassandra_credentials_validity_line }}"
 
+- name: Disable credentials update rate limit
+  lineinfile:
+    path: "{{ cassandra_yml_file }}"
+    regexp: "^#?.*credentials_update_interval"
+    line: "{{ cassandra_credentials_update_interval_line }}"
 
 - name: Add lines for nodetool auth to cassandra-env.sh
   blockinfile:

--- a/tests/integration/targets/setup_cassandra/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra/tasks/main.yml
@@ -287,12 +287,3 @@
     - ansible_distribution_major_version == "7"
   notify: redhat_remove_cassandra
   no_log: yes
-
-- name: Remove textract
-  ansible.builtin.pip:
-    name: textract
-    state: absent
-
-- name: Install six
-  ansible.builtin.pip:
-    name: six

--- a/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
@@ -43,6 +43,14 @@
     state: "stopped"
   ignore_errors: true  # Might not exist
 
+- name: Wait for Cassandra apt service to release port 7000
+  ansible.builtin.wait_for:
+    port: 7000
+    host: 127.0.0.1
+    state: absent
+    timeout: 60
+  ignore_errors: true  # Port may never have been in use
+
 - name: Install sudo
   package:
     name: sudo

--- a/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
@@ -271,15 +271,15 @@
   with_items: "{{ cassandra_nodes }}"
   ignore_errors: true
 
-- name: Assume the start of one node is failing due to a memory issue
-  shell: |
-    sudo -E -u cassandra bash -c '{{ ccm_cmd }} {{ item.node }} updateconf "jvm.options: -Xms256M -Xmx512M"'
-  args:
-    chdir: /home/cassandra
-  environment:
-    CCM_CONFIG_DIR: "/home/cassandra/config"
-    CASSANDRA_HOME: "/home/cassandra"
-    JAVA_HOME: "{{ (ansible_os_family == 'RedHat') | ternary('/usr/lib/jvm/java-' ~ j_version ~ '-openjdk', '/usr/lib/jvm/java-' ~ j_version ~ '-openjdk-amd64') }}"
+- name: Cap JVM heap for CI runners via cassandra-env.sh
+  ansible.builtin.blockinfile:
+    path: "/home/cassandra/config/test/{{ item.node }}/conf/cassandra-env.sh"
+    marker: "# {mark} CI JVM HEAP SETTINGS"
+    block: |
+      MAX_HEAP_SIZE="256M"
+      HEAP_NEWSIZE="256M"
+    owner: cassandra
+    group: cassandra
   with_items: "{{ cassandra_nodes }}"
 
 - name: Get node jvm config info

--- a/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
@@ -49,7 +49,6 @@
     host: 127.0.0.1
     state: absent
     timeout: 60
-  ignore_errors: true  # Port may never have been in use
 
 - name: Install sudo
   package:

--- a/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
@@ -164,10 +164,11 @@
   delay: 5
 
 - name: Install ccm via git
-  ansible.builtin.shell: sudo ./setup.py install
-  args:
-    chdir: /opt/cassandra-ccm
-    creates: /usr/local/bin/ccm
+  ansible.builtin.pip:
+    name: /opt/cassandra-ccm
+    state: present
+    executable: pip3.8
+  become: true
 
 - ansible.builtin.shell: find /usr -name ccm -ls
 
@@ -343,7 +344,3 @@
   ansible.builtin.pip:
     name: textract
     state: absent
-
-- name: Install six
-  ansible.builtin.pip:
-    name: six

--- a/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
@@ -315,8 +315,6 @@
     CCM_CLUSTER_START_DEFAULT_TIMEOUT: "600"
   ignore_errors: true # tmp debug
 
-- shell: ls -lh /home/cassandra/config/*/ && cat /home/cassandra/config/test/marlow11/logs/*
-
 - name: Get cluster status
   ansible.builtin.shell: sudo -E -u cassandra bash -c "{{ ccm_cmd }} status"
   become_user: cassandra

--- a/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
+++ b/tests/integration/targets/setup_cassandra_cluster_manager/tasks/main.yml
@@ -178,15 +178,6 @@
     executable: pip3.8
   become: true
 
-- ansible.builtin.shell: find /usr -name ccm -ls
-
-- name: DEBUG - Test with PATH set
-  ansible.builtin.shell: |
-    which ccm && which ant
-  environment:
-    PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/ant/bin
-  ignore_errors: true
-
 - set_fact:
     ccm_cmd: /usr/local/bin/ccm
 
@@ -313,7 +304,6 @@
     PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/ant/bin
     JAVA_HOME: "{{ (ansible_os_family == 'RedHat') | ternary('/usr/lib/jvm/java-' ~ j_version ~ '-openjdk', '/usr/lib/jvm/java-' ~ j_version ~ '-openjdk-amd64') }}"
     CCM_CLUSTER_START_DEFAULT_TIMEOUT: "600"
-  ignore_errors: true # tmp debug
 
 - name: Get cluster status
   ansible.builtin.shell: sudo -E -u cassandra bash -c "{{ ccm_cmd }} status"
@@ -345,8 +335,3 @@
     delay: 30
     timeout: 600
   with_items: "{{ cassandra_nodes }}"
-
-- name: Remove textract
-  ansible.builtin.pip:
-    name: textract
-    state: absent


### PR DESCRIPTION
This PR fixes a series of CI failures that accumulated after the runner upgrade to ubuntu-24.04 (introduced in #297).

**CCM install:** CCM was installed via `setup.py install`, which used the system Python (3.8). But `six` was only installed in the Python 3.10 environment, so CCM crashed on startup. Fixed by using `pip3.8` directly, which pulls in all dependencies for the right interpreter.

**JVM heap:** The `ccm updateconf "jvm.options: ..."` call silently did nothing — that key doesn't exist in `cassandra.yaml`. Heap sizing is actually controlled by `MAX_HEAP_SIZE`/`HEAP_NEWSIZE` in `cassandra-env.sh`, which Cassandra checks before auto-calculating. In practice, the actual JVM flags live in `jvm.options` / `jvm-server*.options`, but the env vars take precedence.

**Port 7000 race condition:** `setup_cassandra` starts Cassandra on `127.0.0.1:7000`. The `service stop` command returns success before the JVM actually dies, so CCM's `london1` node (also on `127.0.0.1`) would hit "port in use". Added a `wait_for state=absent` to let it fully exit.

**`marlow11` typo:** A leftover debug task with a hardcoded `marlow11` path (should be `marlow1`) had no `ignore_errors`, so it killed the play on every run and triggered a retry that then ran out of memory.

**`cassandra_ssl` JAVA_HOME:** The `ccm start` calls for the SSL clusters were missing `JAVA_HOME` in their environment, causing a `KeyError` in `ccmlib`.

**Drop centos7:** centos7 is EOL since June 2024 and its ansible-test container requires cgroup v1, which is incompatible with the ubuntu-24.04 runners (cgroup v2 only) introduced in #297 — this is likely why it's been broken since then. Removing it shrinks the matrix and eliminates a source of failures that can't be fixed from the collection side.