### PR TITLE
add cassandra_statusbinary and cassandra_statusgossip modules

### DIFF
--- a/plugins/modules/cassandra_statusbinary.py
+++ b/plugins/modules/cassandra_statusbinary.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+
+# 2026 Alain Rodriguez <alain@casterix.fr>
+# https://github.com/arodrime
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+
+DOCUMENTATION = '''
+---
+module: cassandra_statusbinary
+author: Alain Rodriguez (@arodrime)
+short_description: Returns the status of the binary protocol.
+requirements:
+  - nodetool
+description:
+    - Returns the status of the binary protocol, also known as the native transport.
+
+extends_documentation_fragment:
+  - community.cassandra.nodetool_module_options
+'''
+
+EXAMPLES = '''
+- name: Get binary protocol status
+  community.cassandra.cassandra_statusbinary:
+  register: result
+
+- name: Assert binary is running
+  assert:
+    that: result.is_up
+'''
+
+RETURN = '''
+is_up:
+  description: True if the binary protocol is running, False otherwise.
+  returned: success
+  type: bool
+stdout:
+  description: Raw output of the nodetool statusbinary command. Possible values are 'running' or 'not running'.
+  returned: success
+  type: str
+stderr:
+  description: Error output of the nodetool command.
+  returned: when debug is true
+  type: str
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+__metaclass__ = type
+
+
+from ansible_collections.community.cassandra.plugins.module_utils.nodetool_cmd_objects import NodeToolCommandSimple
+from ansible_collections.community.cassandra.plugins.module_utils.cassandra_common_options import cassandra_common_argument_spec
+
+
+def main():
+    argument_spec = cassandra_common_argument_spec()
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    status_cmd = 'statusbinary'
+    n = NodeToolCommandSimple(module, status_cmd)
+
+    result = {}
+
+    (rc, out, err) = n.run_command()
+    out = out.strip()
+
+    if module.params['debug'] and err:
+        result['stderr'] = err
+
+    if rc != 0:
+        module.fail_json(name=status_cmd, msg="statusbinary command failed", **result)
+
+    result['stdout'] = out
+    result['is_up'] = out == 'running'
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/cassandra_statusgossip.py
+++ b/plugins/modules/cassandra_statusgossip.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+
+# 2026 Alain Rodriguez <alain@casterix.fr>
+# https://github.com/arodrime
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+
+DOCUMENTATION = '''
+---
+module: cassandra_statusgossip
+author: Alain Rodriguez (@arodrime)
+short_description: Returns the status of gossip.
+requirements:
+  - nodetool
+description:
+    - Returns the status of gossip.
+
+extends_documentation_fragment:
+  - community.cassandra.nodetool_module_options
+'''
+
+EXAMPLES = '''
+- name: Get gossip status
+  community.cassandra.cassandra_statusgossip:
+  register: result
+
+- name: Assert gossip is running
+  assert:
+    that: result.is_up
+'''
+
+RETURN = '''
+is_up:
+  description: True if gossip is running, False otherwise.
+  returned: success
+  type: bool
+stdout:
+  description: Raw output of the nodetool statusgossip command. Possible values are 'running' or 'not running'.
+  returned: success
+  type: str
+stderr:
+  description: Error output of the nodetool command.
+  returned: when debug is true
+  type: str
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+__metaclass__ = type
+
+
+from ansible_collections.community.cassandra.plugins.module_utils.nodetool_cmd_objects import NodeToolCommandSimple
+from ansible_collections.community.cassandra.plugins.module_utils.cassandra_common_options import cassandra_common_argument_spec
+
+
+def main():
+    argument_spec = cassandra_common_argument_spec()
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    status_cmd = 'statusgossip'
+    n = NodeToolCommandSimple(module, status_cmd)
+
+    result = {}
+
+    (rc, out, err) = n.run_command()
+    out = out.strip()
+
+    if module.params['debug'] and err:
+        result['stderr'] = err
+
+    if rc != 0:
+        module.fail_json(name=status_cmd, msg="statusgossip command failed", **result)
+
+    result['stdout'] = out
+    result['is_up'] = out == 'running'
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/cassandra_statusbinary/meta/main.yml
+++ b/tests/integration/targets/cassandra_statusbinary/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_cassandra

--- a/tests/integration/targets/cassandra_statusbinary/tasks/main.yml
+++ b/tests/integration/targets/cassandra_statusbinary/tasks/main.yml
@@ -1,0 +1,132 @@
+# test code for the cassandra_statusbinary module
+# (c) 2026,  Alain Rodriguez <alain@casterix.fr>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ===========================================================
+- name: Ensure binary is enabled before tests
+  community.cassandra.cassandra_binary:
+    state: "enabled"
+
+- name: Get binary status with module 1
+  community.cassandra.cassandra_statusbinary:
+    debug: true
+  register: statusbinary
+
+- name: Assert binary is running 1
+  assert:
+    that:
+      - statusbinary.is_up
+      - statusbinary.stdout == 'running'
+
+- name: Assert statusbinary did not change
+  assert:
+    that: statusbinary.changed == False
+
+- name: Disable binary
+  community.cassandra.cassandra_binary:
+    state: "disabled"
+
+- name: Get binary status with module 2
+  community.cassandra.cassandra_statusbinary:
+    debug: true
+  register: statusbinary
+
+- name: Assert binary is not running
+  assert:
+    that:
+      - not statusbinary.is_up
+      - statusbinary.stdout == 'not running'
+
+- name: Assert statusbinary did not change
+  assert:
+    that: statusbinary.changed == False
+
+- name: Re-enable binary
+  community.cassandra.cassandra_binary:
+    state: "enabled"
+
+- name: Get binary status with module 3
+  community.cassandra.cassandra_statusbinary:
+    debug: true
+  register: statusbinary
+
+- name: Assert binary is running again
+  assert:
+    that:
+      - statusbinary.is_up
+      - statusbinary.stdout == 'running'
+
+- include_tasks: ../../setup_cassandra/tasks/cassandra_auth.yml
+  when: cassandra_auth_tests == True
+
+- name: Get binary status with auth
+  community.cassandra.cassandra_statusbinary:
+    username: "{{ cassandra_admin_user }}"
+    password: "{{ cassandra_admin_pwd }}"
+    debug: true
+  register: statusbinary
+  when: cassandra_auth_tests == True
+
+- name: Assert binary is running with auth
+  assert:
+    that:
+      - statusbinary.is_up
+      - statusbinary.stdout == 'running'
+  when: cassandra_auth_tests == True
+
+- name: Get binary status using password file
+  community.cassandra.cassandra_statusbinary:
+    username: "{{ cassandra_admin_user }}"
+    password_file: /etc/cassandra/jmxremote.password
+    debug: true
+  register: statusbinary
+  when: cassandra_auth_tests == True
+
+- name: Assert binary is running with password file
+  assert:
+    that:
+      - statusbinary.is_up
+      - statusbinary.stdout == 'running'
+  when: cassandra_auth_tests == True
+
+- name: Test login failure handling
+  community.cassandra.cassandra_statusbinary:
+    username: "{{ cassandra_admin_user }}"
+    password: XXXXXXXXXXXXXXXXXXXXX
+    debug: true
+  register: login_status
+  ignore_errors: true
+  when: cassandra_auth_tests == True
+
+- name: Assert failed login
+  assert:
+    that:
+      - login_status.failed == True
+      - "'Invalid username or password' in login_status.stderr"
+  when: cassandra_auth_tests == True
+
+- name: Test incorrect nodetool_path handling
+  community.cassandra.cassandra_statusbinary:
+    nodetool_path: /tmp
+    debug: true
+  register: nodetool_path_error
+  ignore_errors: true
+
+- name: Assert no such file
+  assert:
+    that:
+      - "'Error executing command' in nodetool_path_error.msg or 'No such file or directory' in nodetool_path_error.msg"

--- a/tests/integration/targets/cassandra_statusbinary/vars/main.yml
+++ b/tests/integration/targets/cassandra_statusbinary/vars/main.yml
@@ -1,0 +1,1 @@
+cassandra_auth_tests: True

--- a/tests/integration/targets/cassandra_statusgossip/meta/main.yml
+++ b/tests/integration/targets/cassandra_statusgossip/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_cassandra

--- a/tests/integration/targets/cassandra_statusgossip/tasks/main.yml
+++ b/tests/integration/targets/cassandra_statusgossip/tasks/main.yml
@@ -1,0 +1,132 @@
+# test code for the cassandra_statusgossip module
+# (c) 2026,  Alain Rodriguez <alain@casterix.fr>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ===========================================================
+- name: Ensure gossip is enabled before tests
+  community.cassandra.cassandra_gossip:
+    state: "enabled"
+
+- name: Get gossip status with module 1
+  community.cassandra.cassandra_statusgossip:
+    debug: true
+  register: statusgossip
+
+- name: Assert gossip is running 1
+  assert:
+    that:
+      - statusgossip.is_up
+      - statusgossip.stdout == 'running'
+
+- name: Assert statusgossip did not change
+  assert:
+    that: statusgossip.changed == False
+
+- name: Disable gossip
+  community.cassandra.cassandra_gossip:
+    state: "disabled"
+
+- name: Get gossip status with module 2
+  community.cassandra.cassandra_statusgossip:
+    debug: true
+  register: statusgossip
+
+- name: Assert gossip is not running
+  assert:
+    that:
+      - not statusgossip.is_up
+      - statusgossip.stdout == 'not running'
+
+- name: Assert statusgossip did not change
+  assert:
+    that: statusgossip.changed == False
+
+- name: Re-enable gossip
+  community.cassandra.cassandra_gossip:
+    state: "enabled"
+
+- name: Get gossip status with module 3
+  community.cassandra.cassandra_statusgossip:
+    debug: true
+  register: statusgossip
+
+- name: Assert gossip is running again
+  assert:
+    that:
+      - statusgossip.is_up
+      - statusgossip.stdout == 'running'
+
+- include_tasks: ../../setup_cassandra/tasks/cassandra_auth.yml
+  when: cassandra_auth_tests == True
+
+- name: Get gossip status with auth
+  community.cassandra.cassandra_statusgossip:
+    username: "{{ cassandra_admin_user }}"
+    password: "{{ cassandra_admin_pwd }}"
+    debug: true
+  register: statusgossip
+  when: cassandra_auth_tests == True
+
+- name: Assert gossip is running with auth
+  assert:
+    that:
+      - statusgossip.is_up
+      - statusgossip.stdout == 'running'
+  when: cassandra_auth_tests == True
+
+- name: Get gossip status using password file
+  community.cassandra.cassandra_statusgossip:
+    username: "{{ cassandra_admin_user }}"
+    password_file: /etc/cassandra/jmxremote.password
+    debug: true
+  register: statusgossip
+  when: cassandra_auth_tests == True
+
+- name: Assert gossip is running with password file
+  assert:
+    that:
+      - statusgossip.is_up
+      - statusgossip.stdout == 'running'
+  when: cassandra_auth_tests == True
+
+- name: Test login failure handling
+  community.cassandra.cassandra_statusgossip:
+    username: "{{ cassandra_admin_user }}"
+    password: XXXXXXXXXXXXXXXXXXXXX
+    debug: true
+  register: login_status
+  ignore_errors: true
+  when: cassandra_auth_tests == True
+
+- name: Assert failed login
+  assert:
+    that:
+      - login_status.failed == True
+      - "'Invalid username or password' in login_status.stderr"
+  when: cassandra_auth_tests == True
+
+- name: Test incorrect nodetool_path handling
+  community.cassandra.cassandra_statusgossip:
+    nodetool_path: /tmp
+    debug: true
+  register: nodetool_path_error
+  ignore_errors: true
+
+- name: Assert no such file
+  assert:
+    that:
+      - "'Error executing command' in nodetool_path_error.msg or 'No such file or directory' in nodetool_path_error.msg"

--- a/tests/integration/targets/cassandra_statusgossip/vars/main.yml
+++ b/tests/integration/targets/cassandra_statusgossip/vars/main.yml
@@ -1,0 +1,1 @@
+cassandra_auth_tests: True


### PR DESCRIPTION
Resolves #325

Add two read-only modules that expose nodetool statusbinary and nodetool statusgossip.

cassandra_binary and cassandra_gossip require specifying a desired state, making them unsuitable for simply querying the current status in a playbook. These modules fill that gap and match the nodetool command naming, avoiding mixing read-only status checks with state-changing commands.

Example usage:

- name: Check binary protocol status
  community.cassandra.cassandra_statusbinary:
  register: result

- name: Proceed only if binary is up
  ansible.builtin.debug:
    msg: "Binary is running"
  when: result.is_up